### PR TITLE
OOIION-76

### DIFF
--- a/ion/services/coi/datastore.py
+++ b/ion/services/coi/datastore.py
@@ -1032,9 +1032,9 @@ class DataStoreWorkbench(WorkBench):
         # max size for a data chunk AND the LRU dict
         LRU_DICT_LIMIT = int(CONF.getValue('extract_cache_size', 5 * 1024 * 1024))
 
-        # @TODO: Bug OOIION- is preventing us from setting a proper chunk limit of 5mb.
-        #                    The overflow point appears to be 16482 -> 16483, which in bytes, looks suspiciously
-        #                    like an arithmetic overflow somewhere.
+        # @TODO: Bug OOIION-159 is preventing us from setting a proper chunk limit of 5mb.
+        #                       The overflow point appears to be 16482 -> 16483, which in bytes, looks suspiciously
+        #                       like an arithmetic overflow somewhere.
 
         CHUNK_FACTOR = 15000 #LRU_DICT_LIMIT / ITEM_SIZE       # chunk factor is expressed in # of items, not bytes
         log.debug("LRU Cache Limit set at %d bytes, CHUNK_FACTOR is %d elements" % (LRU_DICT_LIMIT, CHUNK_FACTOR))


### PR DESCRIPTION
Hi, these commits fix OOIION-76 (https://jira.oceanobservatories.org/tasks/browse/OOIION-76).  DataStore's extract_data is now much more efficient in both speed and memory usage, and has memory use safety by only allowing up to 5mb of bounded array data to be in a cache at any time.

Likely hard to read these as diffs, might want to just look at the datastore.py file itself.  Will ask DavidS @dstuebe to review.
