### PR TITLE
Jira bug: OOIION-381.  Added check for null parameter in getDSourceMetada

### DIFF
--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -308,22 +308,25 @@ class MetadataCache(object):
         Get the dictionary entry containing the metadata from the data source
         represented by the given ResourceID (dSourceID).
         """
-        
-        try:
-            yield self.__lockCache()
-    
-            log.debug('getDSourceMetadata')
-                    
-            metadata = self.__metadata[dSourceID]
-            log.debug('Metadata keys for ' + dSourceID + ': ' + str(metadata.keys()))
-            returnValue = metadata
-        except KeyError:
-            log.info('Metadata not found for datasourceID: ' + dSourceID)
-            returnValue = None
 
-        finally:
-            self.__unlockCache()
-            
+        if dSourceID is None:
+            returnValue = None
+        else:
+            try:
+                yield self.__lockCache()
+        
+                log.debug('getDSourceMetadata')
+                        
+                metadata = self.__metadata[dSourceID]
+                log.debug('Metadata keys for ' + dSourceID + ': ' + str(metadata.keys()))
+                returnValue = metadata
+            except KeyError:
+                log.info('Metadata not found for datasourceID: ' + dSourceID)
+                returnValue = None
+    
+            finally:
+                self.__unlockCache()
+                
         defer.returnValue(returnValue)
     
     


### PR DESCRIPTION
Jira bug: OOIION-381.  Added check for null parameter in getDSourceMetadata.
