### PR TITLE
Ooiion 382

### DIFF
--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -175,6 +175,7 @@ class MetadataCache(object):
             
         defer.returnValue(True)
 
+
     @defer.inlineCallbacks
     def getDSet(self, dSetID):
         """
@@ -183,20 +184,24 @@ class MetadataCache(object):
         object instead of the metadata.
         """
         
-        log.debug('getDSet')
-
-        try:
-            yield self.__lockCache()
-                    
-            metadata = self.__metadata[dSetID]
-            log.debug('Metadata keys for ' + dSetID + ': ' + str(metadata.keys()))
-            returnValue = metadata[DSET]
-        except KeyError:
-            log.error('Metadata not found for datasetID: %s'  %(dSetID))
+        if dSetID is None:
+            log.error('getDSeta: dSetID is None')
             returnValue = None
+        else:          
+            log.debug('getDSet for dSetID %s' %(dSetID))
 
-        finally:
-            self.__unlockCache()
+            try:
+                yield self.__lockCache()
+                        
+                metadata = self.__metadata[dSetID]
+                log.debug('Metadata keys for ' + dSetID + ': ' + str(metadata.keys()))
+                returnValue = metadata[DSET]
+            except KeyError:
+                log.error('Metadata not found for datasetID: %s'  %(dSetID))
+                returnValue = None
+    
+            finally:
+                self.__unlockCache()
         
         defer.returnValue(returnValue)
 
@@ -208,21 +213,24 @@ class MetadataCache(object):
         represented by the given ResourceID (dSetID).
         """
         
-        log.debug('getDSetMetadata')
-
-        try:
-            yield self.__lockCache()
-                    
-            metadata = self.__metadata[dSetID]
-            log.debug('Metadata keys for ' + dSetID + ': ' + str(metadata.keys()))
-            returnValue = metadata
-        except KeyError:
-            log.info('Metadata not found for datasetID: ' + dSetID)
+        if dSetID is None:
+            log.error('getDSetMetadata: dSetID is None')
             returnValue = None
-            
-        finally:            
+        else:            
+            log.debug('getDSetMetadata for dSetID %s' %(dSetID))
 
-            self.__unlockCache()
+            try:
+                yield self.__lockCache()
+                        
+                metadata = self.__metadata[dSetID]
+                log.debug('Metadata keys for ' + dSetID + ': ' + str(metadata.keys()))
+                returnValue = metadata
+            except KeyError:
+                log.info('Metadata not found for datasetID: ' + dSetID)
+                returnValue = None
+                
+            finally:            
+                self.__unlockCache()
         
         defer.returnValue(returnValue)
 
@@ -235,15 +243,18 @@ class MetadataCache(object):
         data set as an argument. 
         """
         
-        log.debug('putDSetMetadata')
+        if dSetID is None:
+            log.error('putDSetMetadata: dSetID is None')
+        else:            
+            log.debug('putDSetMetadata for dSetID %s' %(dSetID))
 
-        try:
-            yield self.__lockCache()
+            try:
+                yield self.__lockCache()
+        
+                yield self.__putDSetMetadata(dSetID)
     
-            yield self.__putDSetMetadata(dSetID)
-
-        finally:
-            self.__unlockCache()
+            finally:
+                self.__unlockCache()
                     
     
     @defer.inlineCallbacks
@@ -252,30 +263,34 @@ class MetadataCache(object):
         Delete the dictionary entry for the data set represented by the given
         resource ID (dSetID).
         """
-        
-        log.debug('deleteDSetMetadata')
 
-        try:
-            yield self.__lockCache()
-
-            #
-            # Set the persistent flag to False
-            #
-            dSetMetadata = self.__metadata[dSetID]
-            dSet = dSetMetadata[DSET]
-            dSet.Repository.persistent = False
-
-            self.__metadata.pop(dSetID)
-        except KeyError:
-            log.error('deleteDSetMetadata: datasetID ' + dSetID + ' not cached')
+        if dSetID is None:
+            log.error('deleteDSetMetadata: DSetID is None')
             returnValue = False
-        else:
-            self.numDSets = self.numDSets - 1
-            returnValue = True
+        else:            
+            log.debug('deleteDSetMetadata: deleting %s' %(dSetID))
 
-        finally:
-            
-            self.__unlockCache()
+            try:
+                yield self.__lockCache()
+    
+                #
+                # Set the persistent flag to False
+                #
+                dSetMetadata = self.__metadata[dSetID]
+                dSet = dSetMetadata[DSET]
+                dSet.Repository.persistent = False
+    
+                self.__metadata.pop(dSetID)
+            except KeyError:
+                log.error('deleteDSetMetadata: datasetID ' + dSetID + ' not cached')
+                returnValue = False
+            else:
+                self.numDSets = self.numDSets - 1
+                returnValue = True
+    
+            finally:
+                
+                self.__unlockCache()
         
         defer.returnValue(returnValue)
 
@@ -287,21 +302,25 @@ class MetadataCache(object):
         represented by the given ResourceID (dSourceID); return the datasource
         object instead of the metadata
         """
-        
-        log.debug('getDSource for: ' + dSourceID)
 
-        try:                    
-            yield self.__lockCache()
-
-            metadata = self.__metadata[dSourceID]
-            log.debug('Metadata keys for ' + dSourceID + ': ' + str(metadata.keys()))
-            returnValue = metadata[DSOURCE]
-        except KeyError:
-            log.error('Metadata not found for datasourceID: ' + dSourceID)
+        if dSourceID is None:
+            log.error('getDSource: dSourceID is None')
             returnValue = None
-
-        finally:
-            self.__unlockCache()
+        else:            
+            log.debug('getDSource for %s' %(dSourceID))
+    
+            try:                    
+                yield self.__lockCache()
+    
+                metadata = self.__metadata[dSourceID]
+                log.debug('Metadata keys for ' + dSourceID + ': ' + str(metadata.keys()))
+                returnValue = metadata[DSOURCE]
+            except KeyError:
+                log.error('Metadata not found for datasourceID: ' + dSourceID)
+                returnValue = None
+    
+            finally:
+                self.__unlockCache()
             
         defer.returnValue(returnValue)            
         
@@ -314,8 +333,11 @@ class MetadataCache(object):
         """
 
         if dSourceID is None:
+            log.error('getDSourceMetadata: dSourceID is None')
             returnValue = None
         else:
+            log.debug('getDSourceMetadata for %s' %(dSourceID))
+            
             try:
                 yield self.__lockCache()
         
@@ -340,16 +362,19 @@ class MetadataCache(object):
         Put the instance of the data source represented by the given resource
         ID (dSourceID). 
         """
-        
-        log.debug('putDSourceMetadata')
 
-        try:
-            yield self.__lockCache()
+        if dSourceID is None:
+            log.error('putDSourceMetadata: dSourceID is None')
+        else:            
+            log.debug('putDSourceMetadata for dSourceID %s' %(dSourceID))
 
-            yield self.__putDSourceMetadata(dSourceID)
-
-        finally:
-            self.__unlockCache()
+            try:
+                yield self.__lockCache()
+    
+                yield self.__putDSourceMetadata(dSourceID)
+    
+            finally:
+                self.__unlockCache()
 
 
     @defer.inlineCallbacks
@@ -359,29 +384,32 @@ class MetadataCache(object):
         resource ID (dSourceID).
         """
         
-        log.debug('deleteDSourceMetadata')
+        if dSourceID is None:
+            log.error('deleteDSourceMetadata: dSourceID is None')
+            returnValue is False
+        else:            
+            log.debug('deleteDSourceMetadata for %s' %(dSourceID))
 
-
-        try:
-            yield self.__lockCache()
-        
-            #
-            # Set the persistent flag to False
-            #
-            dSourceMetadata = self.__metadata[dSourceID]
-            dSource = dSourceMetadata[DSOURCE]
-            dSource.Repository.persistent = False
-
-            self.__metadata.pop(dSourceID)
-        except KeyError:
-            log.error('deleteDSourceMetadata: datasourceID ' + dSourceID + ' not cached')
-            returnValue = False
-        else:
-            self.numDSources = self.numDSources - 1
-            returnValue = True
-
-        finally:
-            self.__unlockCache()
+            try:
+                yield self.__lockCache()
+            
+                #
+                # Set the persistent flag to False
+                #
+                dSourceMetadata = self.__metadata[dSourceID]
+                dSource = dSourceMetadata[DSOURCE]
+                dSource.Repository.persistent = False
+    
+                self.__metadata.pop(dSourceID)
+            except KeyError:
+                log.error('deleteDSourceMetadata: datasourceID ' + dSourceID + ' not cached')
+                returnValue = False
+            else:
+                self.numDSources = self.numDSources - 1
+                returnValue = True
+    
+            finally:
+                self.__unlockCache()
         
         defer.returnValue(returnValue)
 
@@ -392,37 +420,42 @@ class MetadataCache(object):
         Worker class private method to get the data source that associated
         with a given data set.  
         """
-        log.debug('getAssociatedSource() entry')
 
-        try:
-            dSet = yield self.rc.get_instance(dSetID)
-            
-        except ResourceClientError:    
-            log.error('Error getting dataset instance for datasetID: %s!' %(dSetID))
+        if dSetID is None:
+            log.error('getAssociatyedSource: dSetID is None')
             defer.returnValue(None)
-            
-        try:
-            results = yield self.ac.find_associations(obj=dSet, predicate_or_predicates=HAS_A_ID)
+        else:            
+            log.debug('getAssociatedSource for dSetID %s' %(dSetID))
 
-        except AssociationClientError:
-            log.error('Error getting associated data source for Dataset: ' + \
-                      dSet.ResourceIdentity)
-            defer.returnValue(None)
-
-        #
-        # If there is not exactly 1 associated data source, log an error and
-        # return None.  
-        #
-        if len(results) != 1:
-            log.error('Dataset %s has %d associated sources.' %(dSetID, len(results)))
-            defer.returnValue(None)
-        else:
-            for association in results:
-                log.debug('Associated Source for Dataset: ' + \
-                          association.ObjectReference.key + \
-                          ' is: ' + association.SubjectReference.key)
-
-        log.debug('getAssociatedSource() exit: returning: %s' %(association.SubjectReference.key))
+            try:
+                dSet = yield self.rc.get_instance(dSetID)
+                
+            except ResourceClientError:    
+                log.error('Error getting dataset instance for datasetID: %s!' %(dSetID))
+                defer.returnValue(None)
+                
+            try:
+                results = yield self.ac.find_associations(obj=dSet, predicate_or_predicates=HAS_A_ID)
+    
+            except AssociationClientError:
+                log.error('Error getting associated data source for Dataset: ' + \
+                          dSet.ResourceIdentity)
+                defer.returnValue(None)
+    
+            #
+            # If there is not exactly 1 associated data source, log an error and
+            # return None.  
+            #
+            if len(results) != 1:
+                log.error('Dataset %s has %d associated sources.' %(dSetID, len(results)))
+                defer.returnValue(None)
+            else:
+                for association in results:
+                    log.debug('Associated Source for Dataset: ' + \
+                              association.ObjectReference.key + \
+                              ' is: ' + association.SubjectReference.key)
+    
+            log.debug('getAssociatedSource() exit: returning: %s' %(association.SubjectReference.key))
 
         defer.returnValue(association.SubjectReference.key)
 

--- a/ion/integration/ais/test/test_metadata_cache.py
+++ b/ion/integration/ais/test/test_metadata_cache.py
@@ -18,7 +18,7 @@ from ion.core.object import object_utils
 from ion.core.messaging.message_client import MessageClient
 from ion.core.data.storage_configuration_utility import COMMIT_CACHE
 
-from ion.services.coi.resource_registry.resource_client import ResourceClient
+from ion.services.coi.resource_registry.resource_client import ResourceClient, ResourceClientError
 from ion.services.coi.resource_registry.association_client import AssociationClient
 from ion.services.dm.distribution.events import DatasetChangeEventPublisher, \
                                                 DatasourceChangeEventPublisher
@@ -136,6 +136,8 @@ class MetadataCacheTest(IonTestCase):
         log.debug('Instantiated AIS Metadata Cache Object')
         yield self.cache.loadDataSets()
         yield self.cache.loadDataSources()
+
+        self.rc = ResourceClient(subproc)
         
         if self.AnalyzeTiming != None:
             self.TimeStamps.StartTime = time.time()
@@ -210,7 +212,7 @@ class MetadataCacheTest(IonTestCase):
         # metadatacache event handler to complete its work).  Currently
         # waiting 5 seconds for each set of 2 events (dataset & datasource)
         #
-        sleepTime = 5
+        sleepTime = 2
         totalSleepTime = 0
         
         # Setup the publishers
@@ -262,7 +264,229 @@ class MetadataCacheTest(IonTestCase):
     
         # Pause to make sure we catch the message
         log.debug('TestUpdateDataResourceCache waiting %s seconds to shut down...' %(totalSleepTime))
-        yield pu.asleep(sleepTime)
+        yield pu.asleep(totalSleepTime)
         log.debug('TestUpdateDataResourceCache shutting down...')
             
 
+    @defer.inlineCallbacks
+    def test_refreshDatasets(self):
+        log.debug('Testing refreshDataset.')
+        
+        #
+        # The purpose of this test is to test the case where a datasource
+        # is in the inactive state, and therefore the associated dataset
+        # is not loaded into the cache and won't show up in the list of
+        # datasets.  However, when the datasource gets set to actve and
+        # the datasource change event is sent, the associated dataset(s)
+        # should be refreshed and get into the list since their source is
+        # active.
+        #
+
+        #
+        # Setup the sleepTime and totalSleepTime (that we wait for the
+        # metadatacache event handler to complete its work).  Currently
+        # waiting 5 seconds for each set of 2 events (dataset & datasource)
+        #
+        sleepTime = 2
+        
+        # Setup the publishers
+        datasetPublisher = DatasetChangeEventPublisher(process=self._proc)
+        yield datasetPublisher.initialize()
+        yield datasetPublisher.activate()
+ 
+        datasrcPublisher = DatasourceChangeEventPublisher(process=self._proc)
+        yield datasrcPublisher.initialize()
+        yield datasrcPublisher.activate()
+ 
+        # Setup the subscribers
+        log.info('instantiating DatasetUpdateEventSubscriber')
+        self.dataset_subscriber = DatasetUpdateEventSubscriber(self, process = self._proc)
+        yield self.dataset_subscriber.initialize()
+        yield self.dataset_subscriber.activate()
+        
+        log.info('instantiating DatasourceUpdateEventSubscriber')
+        self.datasource_subscriber = DatasourceUpdateEventSubscriber(self, process = self._proc)
+        yield self.datasource_subscriber.initialize()
+        yield self.datasource_subscriber.activate()
+
+        #
+        # Set all ACTIVE datasources to inactive
+        #
+        totalSleepTime = 0
+        numActiveSources = 0
+        dSourceIDChangedList = []
+        dSetIDOrphanList = []
+        dsList = self.cache.getDatasets()
+        origNumDSets = len(dsList)
+        log.debug('List of (%d) datasets returned from metadataCache: %s' %(origNumDSets, dsList))
+        for ds in dsList:
+            #dSetID = ds['ResourceIdentity']
+            dSourceID = ds['DSourceID']
+            
+            try:
+                dSource = yield self.rc.get_instance(dSourceID)
+            except ResourceClientError:    
+                log.error('get_instance failed for data source ID %s !' %(dSourceID))
+            else:
+                #
+                # if the lifecycle state is ACTIVE, set it to RETIRED
+                #
+                if dSource.ResourceLifeCycleState == dSource.ACTIVE:
+                    dSourceIDChangedList.append(dSourceID)
+                    newOrphanIDList = yield self.cache.getAssociatedDatasets(dSource)
+                    for newDSetID in newOrphanIDList:
+                        dSetIDOrphanList.append(newDSetID)
+                    log.debug('dSetIDOrphanList = %s' %(dSetIDOrphanList))
+                    numActiveSources = numActiveSources + 1
+                    log.debug("Setting data source %s lifecycle = retired" %(dSourceID))
+                    dSource.ResourceLifeCycleState = dSource.RETIRED
+                    yield self.rc.put_instance(dSource)
+
+                log.debug('publishing event for dSourceID: %s' %(dSourceID))
+    
+                #
+                # publish the event so the datasource and dataset cache are
+                # refreshed
+                #
+                yield datasrcPublisher.create_and_publish_event(
+                    name = "TestUpdateDataResourceCache",
+                    origin = "SOME DATASOURCE RESOURCE ID",
+                    datasource_id = dSourceID,
+                    )
+
+                #
+                # Increment the sleep time
+                #
+                totalSleepTime = totalSleepTime + sleepTime
+
+        # Pause to give the events time to be processed
+        log.debug('TestUpdateDataResourceCache waiting %s for events to be processed...' %(totalSleepTime))
+        yield pu.asleep(totalSleepTime)
+        log.debug('TestUpdateDataResourceCache continuing...')
+
+        #
+        # Check how many datasets are in the list
+        #
+        dsList = self.cache.getDatasets()
+        log.debug('List of (%d) datasets returned from metadataCache: %s' %(len(dsList), dsList))
+        
+        #
+        # Now simulate what findDataResources would do: getting the list of datasets
+        # (assuming they are in bounds).  At the end of this for loop, there should
+        # be no datasets in the count, because their datasources are inactive.
+        #
+        i = 0
+        for dSetID in dSetIDOrphanList:
+            dSet = yield self.cache.getDSetMetadata(dSetID)
+            if dSet is None:
+                log.info('dSet for dSetID %s is None' %s(dSetID))
+                continue
+            
+            dSourceID = dSet['DSourceID']
+            if dSourceID is None:
+                #
+                # There is no associated ID for this dataset; this is a strange
+                # error and it means that there was no datasource returned by
+                # the association service.  Really shouldn't happen, but it
+                # does sometimes.
+                #
+                log.error('dataset %s has no associated dSourceResID.' %(dSetResID))
+                continue
+
+            dSource = yield self.cache.getDSourceMetadata(dSourceID)
+            if dSource is None:
+                #
+                # The datasource is not cached; this could be because it was deleted
+                # or because the datasource hasn't been added yet.  In any case,
+                # do not include the corresponding dataset in the list; continue
+                # the loop now (after incrementing index)
+                #
+                log.info('metadata not found for datasourceID: ' + dSourceID)
+                continue
+            
+            i = i + 1
+            
+        if i != 0:
+            self.fail('There should be no datasets returned here!')
+
+        #
+        # Now set all datasources that were changed back to ACTIVE
+        #
+        totalSleepTime = 0
+        for dSourceID in dSourceIDChangedList:
+            try:
+                dSource = yield self.rc.get_instance(dSourceID)
+            except ResourceClientError:    
+                log.error('get_instance failed for data source ID %s !' %(dSourceID))
+            else:
+                #
+                # set the lifecycle state to ACTIVE
+                #
+                log.debug("Setting data source %s lifecycle to ACTIVE" %(dSourceID))
+                dSource.ResourceLifeCycleState = dSource.ACTIVE
+                yield self.rc.put_instance(dSource)
+
+                log.debug('publishing event for dSourceID: %s' %(dSourceID))
+    
+                #
+                # publish the event so the datasource and dataset cache are
+                # refreshed
+                #
+                yield datasrcPublisher.create_and_publish_event(
+                    name = "TestUpdateDataResourceCache",
+                    origin = "SOME DATASOURCE RESOURCE ID",
+                    datasource_id = dSourceID,
+                    )
+
+                #
+                # Increment the sleep time
+                #
+                totalSleepTime = totalSleepTime + sleepTime
+            
+        
+        # Pause to give the events time to be processed
+        log.debug('TestUpdateDataResourceCache waiting %s seconds to shut down...' %(totalSleepTime))
+        yield pu.asleep(totalSleepTime)
+        log.debug('TestUpdateDataResourceCache shutting down...')
+
+        #
+        # There should now be origNumDSets datasets in the list
+        #
+        dsList = self.cache.getDatasets()
+        log.debug('List of (%d) datasets returned from metadataCache: %s' %(len(dsList), dsList))
+
+        #
+        # Now get the datasets that would show up in the list (assuming they are in bounds)
+        #
+        i = 0
+        for dSet in dsList:
+            dSourceID = dSet['DSourceID']
+            if dSourceID is None:
+                #
+                # There is no associated ID for this dataset; this is a strange
+                # error and it means that there was no datasource returned by
+                # the association service.  Really shouldn't happen, but it
+                # does sometimes.
+                #
+                log.error('dataset %s has no associated dSourceResID.' %(dSetResID))
+                continue
+
+            dSource = yield self.cache.getDSourceMetadata(dSourceID)
+            if dSource is None:
+                #
+                # The datasource is not cached; this could be because it was deleted
+                # or because the datasource hasn't been added yet.  In any case,
+                # do not include the corresponding dataset in the list; continue
+                # the loop now (after incrementing index)
+                #
+                log.info('metadata not found for datasourceID: ' + dSourceID)
+                continue
+            
+            i = i + 1
+            
+        if i != origNumDSets:
+            self.fail("Incorrect number of datasets; was %d, should be %d." %(i, origNumDSets))
+
+        
+        
+            


### PR DESCRIPTION
Added code to handle the possible case where a datasource change event is received after a dataset change event has occurred, and the datasource was not properly associated with the dataset because of lifecycle state.  Also added parameter guards to metadatacache public methods.
