### PR TITLE
Fix for OOIION-409 - Json serializeble error in loggly

### DIFF
--- a/ion/core/ioninit.py
+++ b/ion/core/ioninit.py
@@ -143,9 +143,16 @@ if loggly_key is not None:
     hostname = platform.node()
     class IonLogglyHandler(hoover.LogglyHttpHandler):
         def emit(self, record):
-            setattr(record, 'hostname', hostname)
-            hoover.LogglyHttpHandler.emit(self, record)
-        
+            try:
+                setattr(record, 'hostname', hostname)
+                hoover.LogglyHttpHandler.emit(self, record)
+
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception, ex:
+                print >> sys.stderr, "ERROR during logging to loggly: %s " % str(ex)
+                self.handleError(record)
+
     loggly_handler = IonLogglyHandler(token=loggly_key)
     loggly_handler.setLevel(logging.DEBUG)
     loggly_formatter = logging.Formatter(

--- a/ion/services/dm/ingestion/ingestion.py
+++ b/ion/services/dm/ingestion/ingestion.py
@@ -544,8 +544,6 @@ class IngestionService(ServiceProcess):
                                                                             conv_id=convid,
                                                                             processing_step="dataset")
 
-        log.info(headers)
-
         if content.MessageType != CDM_DATASET_TYPE:
             raise IngestionError('Expected message type CDM Dataset Type, received %s'
                                  % str(content), content.ResponseCodes.BAD_REQUEST)


### PR DESCRIPTION
The loggly emit method assumes that the log arguments are JSON serializable. There was no exception handling. This causes errors where objects, particularly GPB objects are still being passed in log statements.

TypeError: <ion.core.messaging.message_client.MessageInstance_Wrapper_Dataset object at 0x119610d0> is not JSON serializable

This pull request removes one such offensive abuse of the log and adds exception handling to IonLogglyHandler.
