### PR TITLE
Ingestion/JAW improvements to eliminate repeated data, partially fixes OOIION-248

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -14,4 +14,4 @@ develop =
 # By updating the version here the current state of the service code is tied
 # to a specific version of the ionproto dependency which it is written for.
 [versions]
-ionproto=0.3.34
+ionproto=0.3.34-pl1

--- a/development.cfg
+++ b/development.cfg
@@ -14,4 +14,4 @@ develop =
 # By updating the version here the current state of the service code is tied
 # to a specific version of the ionproto dependency which it is written for.
 [versions]
-ionproto=0.3.34-pl1
+ionproto=0.3.35

--- a/ion/core/object/repository.py
+++ b/ion/core/object/repository.py
@@ -898,8 +898,8 @@ class Repository(ObjectContainer):
                 del self.branches[idx]
                 break
         else:
-            log.info('Branch %s not found!' % name)
-            return
+            log.info(str(self))
+            raise KeyError('Branch Key not found in repository %s: Could not delete branch name "%s"' % (self.repository_key, name))
 
         # Clean up the branch nickname if any...
         for k,v in self.branchnicknames.items():

--- a/ion/integration/eoi/agent/java_agent_wrapper.py
+++ b/ion/integration/eoi/agent/java_agent_wrapper.py
@@ -683,7 +683,8 @@ class JavaAgentWrapper(ServiceProcess):
         if str(datasetID).startswith(TESTING_SIGNIFIER):
             testing = True
         msg.source_type = datasource.source_type
-
+        msg.dataset_id = datasetID
+        msg.datasource_id = dataSourceID
 
         try:
             # Set the start time of this update to the last time in the dataset (ion_time_coverage_end)
@@ -691,6 +692,7 @@ class JavaAgentWrapper(ServiceProcess):
             string_time = dataset.root_group.FindAttributeByName('ion_time_coverage_end')
             start_time_seconds = calendar.timegm(time.strptime(string_time.GetValue(), '%Y-%m-%dT%H:%M:%SZ'))
             start_time_seconds -= int(datasource.starttime_offset_millis * 0.001)
+            msg.is_initial = False
 
         except OOIObjectError, oe:
             # Set the start time of this update to the current time minus the initial start time offset
@@ -701,6 +703,7 @@ class JavaAgentWrapper(ServiceProcess):
             if initial_offset == 0:
                 initial_offset = 86400000 # 1 day in millis
             start_time_seconds = int(time.time() - (initial_offset * 0.001))
+            msg.is_initial = True
 
         except AttributeError, ae:
             # Set the start time of this update to the current time minus the initial start time offset
@@ -711,7 +714,7 @@ class JavaAgentWrapper(ServiceProcess):
             if initial_offset == 0:
                 initial_offset = 86400000 # 1 day in millis
             start_time_seconds = int(time.time() - (initial_offset * 0.001))
-
+            msg.is_initial = True
 
         if testing:
             log.debug('Using Test Delta time....')


### PR DESCRIPTION
- More information sent in context message from JAW to DatasetAgent (required ionproto bump)
- Ingest better handles errors/non-completion from DatasetAgent

Other changes must be made on the Java side to fully resolve OOIION-248 but these changes can be merged into ioncore-python without troubling anything else - the core of the issue resides in the DatasetAgent but it needed more context/help from python services.
