### PR TITLE
Jira Bug OOIION-266: pyflakes cleanup.  Also changed log.error to log.info for keyError.

### DIFF
--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -316,7 +316,7 @@ class MetadataCache(object):
                 log.debug('Metadata keys for ' + dSourceID + ': ' + str(metadata.keys()))
                 returnValue = metadata[DSOURCE]
             except KeyError:
-                log.error('Metadata not found for datasourceID: ' + dSourceID)
+                log.info('Metadata not found for datasourceID: ' + dSourceID)
                 returnValue = None
     
             finally:
@@ -386,7 +386,7 @@ class MetadataCache(object):
         
         if dSourceID is None:
             log.error('deleteDSourceMetadata: dSourceID is None')
-            returnValue is False
+            returnValue = False
         else:            
             log.debug('deleteDSourceMetadata for %s' %(dSourceID))
 


### PR DESCRIPTION
The log.error is the result of a getDSource from metadata that hasn't been added yet.  This was a corner case that apparently hadn't been run into much.
