### PR TITLE
Added handling for the new 'timestep_file_count' field in java_agent_wrap

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -14,4 +14,4 @@ develop =
 # By updating the version here the current state of the service code is tied
 # to a specific version of the ionproto dependency which it is written for.
 [versions]
-ionproto=0.3.37
+ionproto=0.3.39

--- a/ion/integration/ais/manage_data_resource/manage_data_resource.py
+++ b/ion/integration/ais/manage_data_resource/manage_data_resource.py
@@ -638,6 +638,7 @@ class ManageDataResource(object):
         datasrc_resource.update_start_datetime_millis  = msg.update_start_datetime_millis
         datasrc_resource.is_public                     = msg.is_public
         datasrc_resource.visualization_url             = msg.visualization_url
+        datasrc_resource.timestep_file_count           = msg.timestep_file_count
 
         # from bug OOIION-131
         datasrc_resource.initial_starttime_offset_millis  = msg.initial_starttime_offset_millis

--- a/ion/integration/eoi/agent/java_agent_wrapper.py
+++ b/ion/integration/eoi/agent/java_agent_wrapper.py
@@ -578,6 +578,7 @@ class JavaAgentWrapper(ServiceProcess):
         context['dataset_url'] = datasource.dataset_url
         context['ncml_mask'] = datasource.ncml_mask
         context['max_ingest_millis'] = datasource.max_ingest_millis
+        context['timestep_file_count'] = datasource.timestep_file_count
 
         # Add subranges to the context message
         for i, r in enumerate(datasource.sub_ranges):


### PR DESCRIPTION
Added handling for the new 'timestep_file_count' field in java_agent_wrapper.py and manage_data_resource.py.  Addresses OOIION-474
