### PR TITLE
Accumulate length in Datastore extract_data plan generation. Fixes OOIION-489

### DIFF
--- a/ion/services/coi/datastore.py
+++ b/ion/services/coi/datastore.py
@@ -1295,6 +1295,7 @@ class DataStoreWorkbench(WorkBench):
             # can we fit the new strip?
             if curlen + cstrip[3] <= CHUNK_FACTOR:
                 curstep.append(csidx)
+                curlen += cstrip[3]
             else:
                 extraction_plan.append(curstep)
                 curstep = [csidx]


### PR DESCRIPTION
Only to be merged by @dstuebe or @blazetopher with authorization from Tim Ampe.
