### PR TITLE
Ais 496 refactor

### DIFF
--- a/ion/core/process/process.py
+++ b/ion/core/process/process.py
@@ -196,7 +196,7 @@ class Process(BasicLifecycleObject):
 
         # Context default dictionary
         self.context = ContextObject()
-        self._last_context = None
+        #self._last_context = None
 
         self.conversation_context = ConversationContext()
 

--- a/ion/integration/ais/ManageResources/ManageResources.py
+++ b/ion/integration/ais/ManageResources/ManageResources.py
@@ -86,7 +86,6 @@ class ManageResources(object):
       self.asc = AssociationServiceClient(proc=ais)
       self.rc = ais.rc
       self.eclc = EPUControllerListClient(proc=ais)
-      self.metadataCache = ais.getMetadataCache()
 
 
    @defer.inlineCallbacks
@@ -584,12 +583,12 @@ class ManageResources(object):
       LoaderFunc = self.ResourceTypes[ResourceType][4]
       Index = yield LoaderFunc(Response.message_parameters_reference[0], Result)
       if (ResourceType == DATASET_KEY):
-         ResourceID = yield self.metadataCache.getAssociatedSource(Result.ResourceIdentity)
+         ResourceID = yield self.ais.getAssociatedSource(Result.ResourceIdentity)
          Response.message_parameters_reference[0].resource.add()
          Response.message_parameters_reference[0].resource[Index].name = "Data Source ID"
          Response.message_parameters_reference[0].resource[Index].value = ResourceID
       elif (ResourceType == DATASOURCE_KEY):
-         ResourceIDs = yield self.metadataCache.getAssociatedDatasets(Result)
+         ResourceIDs = yield self.ais.getAssociatedDatasets(Result)
          if len(ResourceIDs) == 0:
             ResourceID = 'None'
          else:

--- a/ion/integration/ais/ManageResources/ManageResources.py
+++ b/ion/integration/ais/ManageResources/ManageResources.py
@@ -77,7 +77,7 @@ class ManageResources(object):
                            }
       self.MapGpbTypeToResourceType = {10001 : DATASET_KEY,
                                        1401 : IDENTITY_KEY,
-                                       4503 : DATASOURCE_KEY                                     
+                                       4503 : DATASOURCE_KEY
                                        }
       self.SourceTypes = ['', 'SOS', 'USGS', 'AOML', 'NETCDF_S', 'NETCDF_C']
       self.RequestTypes = ['', 'NONE', 'XBT', 'CTD', 'DAP', 'FTP']
@@ -87,12 +87,14 @@ class ManageResources(object):
       self.rc = ais.rc
       self.eclc = EPUControllerListClient(proc=ais)
 
+      self.ais = ais
+
 
    @defer.inlineCallbacks
    def getResourceTypes (self, msg):
       if log.getEffectiveLevel() <= logging.DEBUG:
          log.debug('ManageResources.getResourceTypes()\n'+str(msg))
-      
+
       # no input for this message, just build AIS response with list of resource types
       Response = yield self.mc.create_instance(AIS_RESPONSE_MSG_TYPE, MessageName='AIS getResourceTypes response')
       Response.message_parameters_reference.add()

--- a/ion/integration/ais/ManageResources/ManageResources.py
+++ b/ion/integration/ais/ManageResources/ManageResources.py
@@ -84,7 +84,7 @@ class ManageResources(object):
 
       self.mc = ais.mc
       self.asc = AssociationServiceClient(proc=ais)
-      self.rc = ResourceClient(proc=ais)
+      self.rc = ais.rc
       self.eclc = EPUControllerListClient(proc=ais)
       self.metadataCache = ais.getMetadataCache()
 

--- a/ion/integration/ais/app_integration_service.py
+++ b/ion/integration/ais/app_integration_service.py
@@ -94,6 +94,7 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
     @defer.inlineCallbacks
     def slc_init(self):
 
+        # Create the Worker that uses the metadata cache
         data_resource_worker = yield self.spawn_worker('data_resource_worker')
         data_resource_worker.metadataCache = MetadataCache(data_resource_worker)
         log.debug('Instantiated AIS Metadata Cache Object')
@@ -108,11 +109,12 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         data_resource_worker.datasource_subscriber = DatasourceUpdateEventSubscriber(process = data_resource_worker)
         data_resource_worker.register_life_cycle_object(data_resource_worker.datasource_subscriber)
         
-        # create worker instances of the many AIS CLASSES
+
         self.FindDataResourcesWorker = FindDataResources(data_resource_worker)
         self.GetDataResourceDetailWorker = GetDataResourceDetail(data_resource_worker)
 
 
+        # create worker instances of the many AIS CLASSES
         manage_resource_worker = yield self.spawn_worker('manage_resource_worker')
         self.ManageResourcesWorker = ManageResources(manage_resource_worker)
         

--- a/ion/integration/ais/app_integration_service.py
+++ b/ion/integration/ais/app_integration_service.py
@@ -15,7 +15,6 @@ import ion.util.ionlog
 log = ion.util.ionlog.getLogger(__name__)
 import logging
 from twisted.internet import defer
-import time
 
 from ion.core.object import object_utils
 from ion.core.process.process import ProcessFactory
@@ -26,12 +25,12 @@ from ion.services.dm.inventory.association_service import AssociationServiceClie
 from ion.services.coi.identity_registry import IdentityRegistryClient, get_broadcast_receiver
 from ion.core.intercept.policy import load_roles_from_associations, map_ooi_id_to_role, unmap_ooi_id_from_role
 
-# import GPB type identifiers for AIS
-from ion.integration.ais.ais_object_identifiers import AIS_REQUEST_MSG_TYPE, \
-                                                       AIS_RESPONSE_ERROR_TYPE
+from ion.core.process.process import Process
 
 # import working classes for AIS
 from ion.integration.ais.common.metadata_cache import  MetadataCache
+from ion.integration.ais.common.ais_utils import AIS_Mixin
+
 from ion.integration.ais.findDataResources.findDataResources import FindDataResources, \
                                                                     DatasetUpdateEventSubscriber, \
                                                                     DatasourceUpdateEventSubscriber
@@ -44,11 +43,7 @@ from ion.integration.ais.validate_data_resource.validate_data_resource import Va
 from ion.integration.ais.manage_data_resource_subscription.manage_data_resource_subscription import ManageDataResourceSubscription
 
 
-addresslink_type = object_utils.create_type_identifier(object_id=20003, version=1)
-person_type = object_utils.create_type_identifier(object_id=20001, version=1)
-
-
-class AppIntegrationService(ServiceProcess):
+class AppIntegrationService(ServiceProcess, AIS_Mixin):
     """
     Service to provide clients access to backend data
     """
@@ -57,23 +52,6 @@ class AppIntegrationService(ServiceProcess):
                                              version='0.1.0',
                                              dependencies=[])
 
-    # set to None to turn off timing logging, set to anything else to turn on timing logging
-    AnalyzeTiming = None
-    
-    class TimeStampsClass (object):
-        pass
-    
-    TimeStamps = TimeStampsClass()
-    
-    def TimeStamp (self):
-        TimeNow = time.time()
-        TimeStampStr = "(wall time = " + str (TimeNow) + \
-                       ", elapse time = " + str(TimeNow - self.TimeStamps.StartTime) + \
-                       ", delta time = " + str(TimeNow - self.TimeStamps.LastTime) + \
-                       ")"
-        self.TimeStamps.LastTime = TimeNow
-        return TimeStampStr
-    
 
     def __init__(self, *args, **kwargs):
 
@@ -85,31 +63,71 @@ class AppIntegrationService(ServiceProcess):
     
         log.debug('AppIntegrationService.__init__()')
 
+    @defer.inlineCallbacks
+    def spawn_worker(self,name):
+        """
+        For now - keep it simple and use register life cycle object to control the workers.
+
+        Consider changing to use spanw child - but we need to get the actual instance object not just the id...
+
+        """
+
+        class AIS_Worker_Process(Process, AIS_Mixin):
+            """
+            Worker process for the AIS service
+            """
+
+        worker = AIS_Worker_Process(**{'prcoc-name':name})
+
+        worker.mc = worker.message_client
+        worker.rc = ResourceClient(worker)
+
+        worker.getMetadataCache = AppIntegrationService.getMetadataCache
+
+        yield worker.spawn()
+
+        yield self.register_life_cycle_object(worker)
+
+        defer.returnValue(worker)
+
 
     @defer.inlineCallbacks
     def slc_init(self):
-        self.metadataCache = MetadataCache(self)
+
+        data_resource_worker = yield self.spawn_worker('data_resource_worker')
+        data_resource_worker.metadataCache = MetadataCache(data_resource_worker)
         log.debug('Instantiated AIS Metadata Cache Object')
-        yield self.metadataCache.loadDataSets()
-        yield self.metadataCache.loadDataSources()
+        yield data_resource_worker.metadataCache.loadDataSets()
+        yield data_resource_worker.metadataCache.loadDataSources()
 
         log.info('instantiating DatasetUpdateEventSubscriber')
-        self.dataset_subscriber = DatasetUpdateEventSubscriber(process = self)
-        self.register_life_cycle_object(self.dataset_subscriber)
+        data_resource_worker.dataset_subscriber = DatasetUpdateEventSubscriber(process = data_resource_worker)
+        data_resource_worker.register_life_cycle_object(data_resource_worker.dataset_subscriber)
         
         log.info('instantiating DatasourceUpdateEventSubscriber')
-        self.datasource_subscriber = DatasourceUpdateEventSubscriber(process = self)
-        self.register_life_cycle_object(self.datasource_subscriber)
+        data_resource_worker.datasource_subscriber = DatasourceUpdateEventSubscriber(process = data_resource_worker)
+        data_resource_worker.register_life_cycle_object(data_resource_worker.datasource_subscriber)
         
-        # create worker instances
-        self.FindDataResourcesWorker = FindDataResources(self)
-        self.GetDataResourceDetailWorker = GetDataResourceDetail(self)       
+        # create worker instances of the many AIS CLASSES
+        self.FindDataResourcesWorker = FindDataResources(data_resource_worker)
+        self.GetDataResourceDetailWorker = GetDataResourceDetail(data_resource_worker)
+
+
+        manage_resource_worker = yield self.spawn_worker('manage_resource_worker')
+        self.ManageResourcesWorker = ManageResources(manage_resource_worker)
+        
+        manage_data_resource_worker = yield self.spawn_worker('manage_data_resource_worker')
+        self.ManageDataResourceWorker = ManageDataResource(manage_data_resource_worker)
+
+        manage_subscription_worker = yield self.spawn_worker('manage_subscription_worker')
+        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(manage_subscription_worker)
+
+
+        # These are okay to use self... they don't use resources
         self.CreateDownloadURLWorker = CreateDownloadURL(self)
         self.RegisterUserWorker = RegisterUser(self)
-        self.ManageResourcesWorker = ManageResources(self)
-        self.ManageDataResourcWworker = ManageDataResource(self)
         self.ValidateDataResourceWorker = ValidateDataResource(self)
-        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(self)
+
 
     @defer.inlineCallbacks
     def slc_activate(self):
@@ -118,9 +136,6 @@ class AppIntegrationService(ServiceProcess):
 
         # Load current role associations
         yield load_roles_from_associations(self.asc)
-        
-    def getMetadataCache(self):
-        return self.metadataCache
 
     def op_broadcast(self, content, headers, msg):
         """
@@ -248,7 +263,7 @@ class AppIntegrationService(ServiceProcess):
         @brief create a new data resource
         """
         log.debug('op_createDataResource: \n'+str(content))
-        response = yield self.ManageDataResourcWworker.create(content);
+        response = yield self.ManageDataResourceWorker.create(content);
         yield self.reply_ok(msg, response)
 
     @defer.inlineCallbacks
@@ -258,7 +273,7 @@ class AppIntegrationService(ServiceProcess):
         """
         if log.getEffectiveLevel() <= logging.DEBUG:
             log.debug('op_updateDataResource: \n'+str(content))
-        response = yield self.ManageDataResourcWworker.update(content);
+        response = yield self.ManageDataResourceWorker.update(content);
         yield self.reply_ok(msg, response)
 
     @defer.inlineCallbacks
@@ -268,7 +283,7 @@ class AppIntegrationService(ServiceProcess):
         """
         if log.getEffectiveLevel() <= logging.DEBUG:
             log.debug('op_deleteDataResource: \n'+str(content))
-        response = yield self.ManageDataResourcWworker.delete(content);
+        response = yield self.ManageDataResourceWorker.delete(content);
         yield self.reply_ok(msg, response)
 
     @defer.inlineCallbacks

--- a/ion/integration/ais/app_integration_service.py
+++ b/ion/integration/ais/app_integration_service.py
@@ -82,7 +82,7 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         worker.mc = worker.message_client
         worker.rc = ResourceClient(worker)
 
-        worker.getMetadataCache = AppIntegrationService.getMetadataCache
+        worker.asc = AssociationServiceClient(proc = worker)
 
         yield worker.spawn()
 
@@ -94,42 +94,92 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
     @defer.inlineCallbacks
     def slc_init(self):
 
-        # Create the Worker that uses the metadata cache
+        #== Create a process for the metadata cache and data resource workers
         data_resource_worker = yield self.spawn_worker('data_resource_worker')
-        data_resource_worker.metadataCache = MetadataCache(data_resource_worker)
+        self._data_resource_worker = data_resource_worker
+
+        metadataCache = MetadataCache(data_resource_worker)
+        data_resource_worker.metadataCache = metadataCache
         log.debug('Instantiated AIS Metadata Cache Object')
         yield data_resource_worker.metadataCache.loadDataSets()
         yield data_resource_worker.metadataCache.loadDataSources()
 
         log.info('instantiating DatasetUpdateEventSubscriber')
         data_resource_worker.dataset_subscriber = DatasetUpdateEventSubscriber(process = data_resource_worker)
-        data_resource_worker.register_life_cycle_object(data_resource_worker.dataset_subscriber)
+        yield data_resource_worker.register_life_cycle_object(data_resource_worker.dataset_subscriber)
         
         log.info('instantiating DatasourceUpdateEventSubscriber')
         data_resource_worker.datasource_subscriber = DatasourceUpdateEventSubscriber(process = data_resource_worker)
-        data_resource_worker.register_life_cycle_object(data_resource_worker.datasource_subscriber)
-        
-
-        self.FindDataResourcesWorker = FindDataResources(data_resource_worker)
-        self.GetDataResourceDetailWorker = GetDataResourceDetail(data_resource_worker)
+        yield data_resource_worker.register_life_cycle_object(data_resource_worker.datasource_subscriber)
 
 
-        # create worker instances of the many AIS CLASSES
-        manage_resource_worker = yield self.spawn_worker('manage_resource_worker')
-        self.ManageResourcesWorker = ManageResources(manage_resource_worker)
-        
-        manage_data_resource_worker = yield self.spawn_worker('manage_data_resource_worker')
-        self.ManageDataResourceWorker = ManageDataResource(manage_data_resource_worker)
-
-        manage_subscription_worker = yield self.spawn_worker('manage_subscription_worker')
-        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(manage_subscription_worker)
+        self.FindDataResourcesWorker = FindDataResources(self, metadataCache)
+        self.GetDataResourceDetailWorker = GetDataResourceDetail(self, metadataCache)
 
 
-        # These are okay to use self... they don't use resources
+        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(self, metadataCache)
+
+        self.ManageResourcesWorker = ManageResources(self)
+
+        self.ManageDataResourceWorker = ManageDataResource(self)
+
         self.CreateDownloadURLWorker = CreateDownloadURL(self)
         self.RegisterUserWorker = RegisterUser(self)
         self.ValidateDataResourceWorker = ValidateDataResource(self)
 
+
+        """
+        self.FindDataResourcesWorker = FindDataResources(data_resource_worker)
+        self.GetDataResourceDetailWorker = GetDataResourceDetail(data_resource_worker)
+
+        # Clear up the junk left over from startup
+        data_resource_worker.workbench.manage_workbench_cache('Default Context')
+        #=== End
+
+        #== Create a process for the manage data resource subscription worker
+        manage_subscription_worker = yield self.spawn_worker('manage_subscription_worker')
+        # This is cheating - passing in the matadata cache object - but I think it is safe
+        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(manage_subscription_worker, data_resource_worker.metadataCache)
+        self._manage_subscription_worker = manage_subscription_worker
+
+        # Clear up the junk left over from startup
+        manage_subscription_worker.workbench.manage_workbench_cache('Default Context')
+        #== End
+
+
+        #== Create a process for the Manage Resource worker
+        manage_resource_worker = yield self.spawn_worker('manage_resource_worker')
+        self.ManageResourcesWorker = ManageResources(manage_resource_worker)
+
+        self._manage_resource_worker = manage_resource_worker
+
+        # Clear up the junk left over from startup
+        manage_resource_worker.workbench.manage_workbench_cache('Default Context')
+        #== End
+
+        #== Create a process for the Manage Data Resource worker
+        manage_data_resource_worker = yield self.spawn_worker('manage_data_resource_worker')
+        self.ManageDataResourceWorker = ManageDataResource(manage_data_resource_worker)
+
+        self._manage_data_resource_worker = manage_data_resource_worker
+
+        # Clear up the junk left over from startup
+        manage_data_resource_worker.workbench.manage_workbench_cache('Default Context')
+        #== End
+
+        # These are okay to use self... they don't use resources
+        non_resource_worker = yield self.spawn_worker('non_resource_worker')
+
+        self.CreateDownloadURLWorker = CreateDownloadURL(non_resource_worker)
+        self.RegisterUserWorker = RegisterUser(non_resource_worker)
+        self.ValidateDataResourceWorker = ValidateDataResource(non_resource_worker)
+
+        self._non_resource_worker = non_resource_worker
+        # Clear up the junk left over from startup
+        non_resource_worker.workbench.manage_workbench_cache('Default Context')
+        #== End
+
+        """
 
     @defer.inlineCallbacks
     def slc_activate(self):
@@ -152,6 +202,30 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
                 map_ooi_id_to_role(content['user-id'], content['role'])
             elif op == 'unset_user_role':
                 unmap_ooi_id_from_role(content['user-id'], content['role'])
+
+
+    def DataResourceMemManager(op):
+
+        def call_op(self, *args, **kwargs):
+
+            op_name = op.__name__
+            print 'ais_mem_manager'
+            print 'Worker Process: %s' % self._data_resource_worker
+            print 'op name', op_name, op
+            self._data_resource_worker.context.progenitor_convid = 'data_resource_worker'
+            #print 'Workbench: %s' % self._data_resource_worker.workbench
+            #print 'args', args
+            #print 'kwargs', kwargs
+
+            result = op(self, *args, **kwargs)
+
+            self._data_resource_worker.workbench.manage_workbench_cache('data_resource_worker')
+            print 'Workbench: %s' % self._data_resource_worker.workbench
+
+
+            return result
+        return call_op
+
 
     @defer.inlineCallbacks
     def op_findDataResources(self, content, headers, msg):
@@ -191,6 +265,29 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         log.info('op_getDataResourceDetail service method')
         returnValue = yield self.GetDataResourceDetailWorker.getDataResourceDetail(content)
         yield self.reply_ok(msg, returnValue)
+
+
+    def NonResourceMemManager(op):
+
+        def call_op(self, *args, **kwargs):
+
+            op_name = op.__name__
+            print 'ais_mem_manager'
+            print 'Worker Process: %s' % self._non_resource_worker
+            print 'op name', op_name, op
+            self._non_resource_worker.context = self.context
+            #print 'Workbench: %s' % self._data_resource_worker.workbench
+            #print 'args', args
+            #print 'kwargs', kwargs
+
+            result = op(self, *args, **kwargs)
+
+            self._non_resource_worker.workbench.manage_workbench_cache('data_resource_worker')
+            print 'Workbench: %s' % self._non_resource_worker.workbench
+
+            return result
+        return call_op
+
 
     @defer.inlineCallbacks
     def op_createDownloadURL(self, content, headers, msg):

--- a/ion/integration/ais/app_integration_service.py
+++ b/ion/integration/ais/app_integration_service.py
@@ -113,9 +113,10 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         yield data_resource_worker.register_life_cycle_object(data_resource_worker.datasource_subscriber)
 
 
+        data_resource_worker.workbench.manage_workbench_cache('Default Context')
+
         self.FindDataResourcesWorker = FindDataResources(self, metadataCache)
         self.GetDataResourceDetailWorker = GetDataResourceDetail(self, metadataCache)
-
 
         self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(self, metadataCache)
 
@@ -126,60 +127,6 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         self.CreateDownloadURLWorker = CreateDownloadURL(self)
         self.RegisterUserWorker = RegisterUser(self)
         self.ValidateDataResourceWorker = ValidateDataResource(self)
-
-
-        """
-        self.FindDataResourcesWorker = FindDataResources(data_resource_worker)
-        self.GetDataResourceDetailWorker = GetDataResourceDetail(data_resource_worker)
-
-        # Clear up the junk left over from startup
-        data_resource_worker.workbench.manage_workbench_cache('Default Context')
-        #=== End
-
-        #== Create a process for the manage data resource subscription worker
-        manage_subscription_worker = yield self.spawn_worker('manage_subscription_worker')
-        # This is cheating - passing in the matadata cache object - but I think it is safe
-        self.ManageDataResourceSubscriptionWorker = ManageDataResourceSubscription(manage_subscription_worker, data_resource_worker.metadataCache)
-        self._manage_subscription_worker = manage_subscription_worker
-
-        # Clear up the junk left over from startup
-        manage_subscription_worker.workbench.manage_workbench_cache('Default Context')
-        #== End
-
-
-        #== Create a process for the Manage Resource worker
-        manage_resource_worker = yield self.spawn_worker('manage_resource_worker')
-        self.ManageResourcesWorker = ManageResources(manage_resource_worker)
-
-        self._manage_resource_worker = manage_resource_worker
-
-        # Clear up the junk left over from startup
-        manage_resource_worker.workbench.manage_workbench_cache('Default Context')
-        #== End
-
-        #== Create a process for the Manage Data Resource worker
-        manage_data_resource_worker = yield self.spawn_worker('manage_data_resource_worker')
-        self.ManageDataResourceWorker = ManageDataResource(manage_data_resource_worker)
-
-        self._manage_data_resource_worker = manage_data_resource_worker
-
-        # Clear up the junk left over from startup
-        manage_data_resource_worker.workbench.manage_workbench_cache('Default Context')
-        #== End
-
-        # These are okay to use self... they don't use resources
-        non_resource_worker = yield self.spawn_worker('non_resource_worker')
-
-        self.CreateDownloadURLWorker = CreateDownloadURL(non_resource_worker)
-        self.RegisterUserWorker = RegisterUser(non_resource_worker)
-        self.ValidateDataResourceWorker = ValidateDataResource(non_resource_worker)
-
-        self._non_resource_worker = non_resource_worker
-        # Clear up the junk left over from startup
-        non_resource_worker.workbench.manage_workbench_cache('Default Context')
-        #== End
-
-        """
 
     @defer.inlineCallbacks
     def slc_activate(self):
@@ -202,29 +149,6 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
                 map_ooi_id_to_role(content['user-id'], content['role'])
             elif op == 'unset_user_role':
                 unmap_ooi_id_from_role(content['user-id'], content['role'])
-
-
-    def DataResourceMemManager(op):
-
-        def call_op(self, *args, **kwargs):
-
-            op_name = op.__name__
-            print 'ais_mem_manager'
-            print 'Worker Process: %s' % self._data_resource_worker
-            print 'op name', op_name, op
-            self._data_resource_worker.context.progenitor_convid = 'data_resource_worker'
-            #print 'Workbench: %s' % self._data_resource_worker.workbench
-            #print 'args', args
-            #print 'kwargs', kwargs
-
-            result = op(self, *args, **kwargs)
-
-            self._data_resource_worker.workbench.manage_workbench_cache('data_resource_worker')
-            print 'Workbench: %s' % self._data_resource_worker.workbench
-
-
-            return result
-        return call_op
 
 
     @defer.inlineCallbacks
@@ -265,28 +189,6 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
         log.info('op_getDataResourceDetail service method')
         returnValue = yield self.GetDataResourceDetailWorker.getDataResourceDetail(content)
         yield self.reply_ok(msg, returnValue)
-
-
-    def NonResourceMemManager(op):
-
-        def call_op(self, *args, **kwargs):
-
-            op_name = op.__name__
-            print 'ais_mem_manager'
-            print 'Worker Process: %s' % self._non_resource_worker
-            print 'op name', op_name, op
-            self._non_resource_worker.context = self.context
-            #print 'Workbench: %s' % self._data_resource_worker.workbench
-            #print 'args', args
-            #print 'kwargs', kwargs
-
-            result = op(self, *args, **kwargs)
-
-            self._non_resource_worker.workbench.manage_workbench_cache('data_resource_worker')
-            print 'Workbench: %s' % self._non_resource_worker.workbench
-
-            return result
-        return call_op
 
 
     @defer.inlineCallbacks

--- a/ion/integration/ais/app_integration_service.py
+++ b/ion/integration/ais/app_integration_service.py
@@ -77,7 +77,7 @@ class AppIntegrationService(ServiceProcess, AIS_Mixin):
             Worker process for the AIS service
             """
 
-        worker = AIS_Worker_Process(**{'prcoc-name':name})
+        worker = AIS_Worker_Process(**{'proc-name':name})
 
         worker.mc = worker.message_client
         worker.rc = ResourceClient(worker)

--- a/ion/integration/ais/common/ais_utils.py
+++ b/ion/integration/ais/common/ais_utils.py
@@ -4,7 +4,7 @@ import time
 
 from twisted.internet import defer
 
-from ion.services.dm.inventory.association_service import AssociationServiceClient, AssociationServiceError, ASSOCIATION_GET_STAR_MSG_TYPE
+from ion.services.dm.inventory.association_service import AssociationServiceError, ASSOCIATION_GET_STAR_MSG_TYPE
 from ion.services.dm.inventory.association_service import PREDICATE_OBJECT_QUERY_TYPE, \
     SUBJECT_PREDICATE_QUERY_TYPE, IDREF_TYPE, PREDICATE_REFERENCE_TYPE
 from ion.services.coi.datastore_bootstrap.ion_preload_config import TYPE_OF_ID, \
@@ -14,9 +14,9 @@ from ion.services.coi.datastore_bootstrap.ion_preload_config import TYPE_OF_ID, 
 
 import ion.util.ionlog
 log = ion.util.ionlog.getLogger(__name__)
-import logging
 
-class AIS_Mixin(object)
+
+class AIS_Mixin(object):
 
 
     # set to None to turn off timing logging, set to anything else to turn on timing logging

--- a/ion/integration/ais/common/ais_utils.py
+++ b/ion/integration/ais/common/ais_utils.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+import time
+
+from twisted.internet import defer
+
+from ion.services.dm.inventory.association_service import AssociationServiceClient, AssociationServiceError, ASSOCIATION_GET_STAR_MSG_TYPE
+from ion.services.dm.inventory.association_service import PREDICATE_OBJECT_QUERY_TYPE, \
+    SUBJECT_PREDICATE_QUERY_TYPE, IDREF_TYPE, PREDICATE_REFERENCE_TYPE
+from ion.services.coi.datastore_bootstrap.ion_preload_config import TYPE_OF_ID, \
+    DATASET_RESOURCE_TYPE_ID, DATASOURCE_RESOURCE_TYPE_ID, HAS_A_ID, OWNED_BY_ID
+
+
+
+import ion.util.ionlog
+log = ion.util.ionlog.getLogger(__name__)
+import logging
+
+class AIS_Mixin(object)
+
+
+    # set to None to turn off timing logging, set to anything else to turn on timing logging
+    AnalyzeTiming = None
+
+    class TimeStampsClass(object):
+        pass
+
+    TimeStamps = TimeStampsClass()
+
+
+    @defer.inlineCallbacks
+    def findResourcesOfType(self, resourceType):
+        """
+        A utility method to find all resources of the given type (resourceType).
+        """
+
+        request = yield self.mc.create_instance(PREDICATE_OBJECT_QUERY_TYPE)
+
+        #
+        # Set up a resource type search term using:
+        # - TYPE_OF_ID as predicate
+        # - object of type: resourceType parameter as object
+        #
+        pair = request.pairs.add()
+
+        # ..(predicate)
+        pref = request.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pref.key = TYPE_OF_ID
+
+        pair.predicate = pref
+
+        # ..(object)
+        type_ref = request.CreateObject(IDREF_TYPE)
+        type_ref.key = resourceType
+
+        pair.object = type_ref
+
+        try:
+            result = yield self.asc.get_subjects(request)
+
+        except AssociationServiceError:
+            log.error('__findResourcesOfType: association error!')
+            defer.returnValue(None)
+
+        defer.returnValue(result)
+
+
+    @defer.inlineCallbacks
+    def getAssociatedOwner(self, dsID):
+        """
+        Worker class method to find the owner associated with a data set.
+        This is a public method because it can be called from the
+        findDataResourceDetail worker class.
+        """
+        log.debug('getAssociatedOwner() entry')
+
+        request = yield self.mc.create_instance(SUBJECT_PREDICATE_QUERY_TYPE)
+
+        #
+        # Set up an owned_by_id search term using:
+        # - OWNED_BY_ID as predicate
+        # - LCS_REFERENCE_TYPE object set to ACTIVE as object
+        #
+        pair = request.pairs.add()
+
+        # ..(predicate)
+        pref = request.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pref.key = OWNED_BY_ID
+
+        pair.predicate = pref
+
+        # ..(subject)
+        type_ref = request.CreateObject(IDREF_TYPE)
+        type_ref.key = dsID
+
+        pair.subject = type_ref
+
+        log.info('Calling get_objects with dsID: ' + dsID)
+
+        try:
+            result = yield self.asc.get_objects(request)
+
+        except AssociationServiceError:
+            log.error('getAssociatedOwner: association error!')
+            defer.returnValue(None)
+
+        if len(result.idrefs) == 0:
+            log.error('Owner not found!')
+            defer.returnValue('OWNER NOT FOUND!')
+        elif len(result.idrefs) == 1:
+            log.debug('getAssociatedOwner() exit')
+            defer.returnValue(result.idrefs[0].key)
+        else:
+            log.error('More than 1 owner found!')
+            defer.returnValue('MULTIPLE OWNERS!')
+
+
+
+    @defer.inlineCallbacks
+    def getAssociatedSource(self, dSetID):
+        """
+        Worker class private method to get the data source that associated
+        with a given data set.
+        """
+
+        if dSetID is None:
+            log.error('getAssociatedSource: dSetID is None')
+            defer.returnValue(None)
+
+        log.debug('getAssociatedSource for dSetID %s' %(dSetID))
+
+        qmsg = yield self.mc.create_instance(PREDICATE_OBJECT_QUERY_TYPE)
+        pair = qmsg.pairs.add()
+        pair.object = qmsg.CreateObject(IDREF_TYPE)
+        pair.object.key = dSetID
+        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pair.predicate.key = HAS_A_ID
+
+        pair = qmsg.pairs.add()
+        pair.object = qmsg.CreateObject(IDREF_TYPE)
+        pair.object.key = DATASOURCE_RESOURCE_TYPE_ID
+        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pair.predicate.key = TYPE_OF_ID
+        try:
+            results = yield self.asc.get_subjects(qmsg)
+        except:
+            log.exception('Error getting associated data source for Dataset: %s' % dSetID)
+            defer.returnValue(None)
+
+        dsrcs = [str(x.key) for x in results.idrefs]
+
+        # we expect one:
+        if len(dsrcs) != 1:
+            log.error('Expected 1 datasource, got %d' % len(dsrcs))
+            defer.returnValue(None)
+
+        log.debug('getAssociatedSource() exit: returning: %s' % dsrcs[0])
+
+        defer.returnValue(dsrcs[0])
+
+    @defer.inlineCallbacks
+    def getAssociatedDatasets(self, dSource):
+        """
+        Worker class private method to get the data sets that associated
+        with a given data source.
+        """
+        log.debug('getAssociatedDatasets() entry')
+
+        dSetList = []
+
+        if dSource is None:
+            log.error('getAssociatedDatasets: dSource parameter is None')
+            defer.returnValue(dSetList)
+
+        qmsg = yield self.mc.create_instance(ASSOCIATION_GET_STAR_MSG_TYPE)
+        pair = qmsg.subject_pairs.add()
+        pair.subject = qmsg.CreateObject(IDREF_TYPE)
+        pair.subject.key = dSource.ResourceIdentity
+        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pair.predicate.key = HAS_A_ID
+
+        pair = qmsg.object_pairs.add()
+        pair.object = qmsg.CreateObject(IDREF_TYPE)
+        pair.object.key = DATASET_RESOURCE_TYPE_ID
+        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
+        pair.predicate.key = TYPE_OF_ID
+        try:
+            results = yield self.asc.get_star(qmsg)
+        except:
+            log.error('Error getting associated data sets for Datasource: ' + \
+                      dSource.ResourceIdentity)
+            defer.returnValue([])
+
+        dsets = [str(x.key) for x in results.idrefs]
+
+        log.info('Datasource %s has %d associated datasets.' %(dSource.ResourceIdentity, len(dsets)))
+        log.debug('getAssociatedDatasets) exit: returning: %s' %(str(dsets)))
+
+        defer.returnValue(dsets)
+
+
+    def TimeStamp (self):
+        TimeNow = time.time()
+        TimeStampStr = "(wall time = " + str (TimeNow) + \
+                       ", elapse time = " + str(TimeNow - self.TimeStamps.StartTime) + \
+                       ", delta time = " + str(TimeNow - self.TimeStamps.LastTime) + \
+                       ")"
+        self.TimeStamps.LastTime = TimeNow
+        return TimeStampStr
+
+    def getMetadataCache(self):
+        if hasattr(self, 'metadataCache'):
+            return self.metadataCache
+        else:
+            return None

--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -84,9 +84,6 @@ class MetadataCache(AIS_Mixin):
     Most of the other AIS workers use an instance of the AIS worker process which is a proper mixin
     """
 
-
-    __metadata = {}
-
     def __init__(self, ais):
         log.info('MetadataCache.__init__()')
 
@@ -97,6 +94,9 @@ class MetadataCache(AIS_Mixin):
 
         self.numDSets    = 0
         self.numDSources = 0
+
+        self.__metadata = {}
+
 
         #
         # A lock to ensure exclusive access to cache when updating

--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -78,7 +78,13 @@ VISUALIZATION_URL = 'visualization_url'
 VISIBILITY = 'visibility'
 
 class MetadataCache(AIS_Mixin):
-    
+    """
+    Metadata cache inherits from mixin because it used to contain most of these methods.
+
+    Most of the other AIS workers use an instance of the AIS worker process which is a proper mixin
+    """
+
+
     __metadata = {}
 
     def __init__(self, ais):

--- a/ion/integration/ais/common/metadata_cache.py
+++ b/ion/integration/ais/common/metadata_cache.py
@@ -25,11 +25,12 @@ from ion.services.coi.resource_registry.association_client import AssociationCli
 
 from ion.services.dm.inventory.association_service import AssociationServiceClient, AssociationServiceError, ASSOCIATION_GET_STAR_MSG_TYPE
 from ion.services.dm.inventory.association_service import PREDICATE_OBJECT_QUERY_TYPE, \
-    SUBJECT_PREDICATE_QUERY_TYPE, IDREF_TYPE
+    SUBJECT_PREDICATE_QUERY_TYPE, IDREF_TYPE, PREDICATE_REFERENCE_TYPE
 from ion.services.coi.datastore_bootstrap.ion_preload_config import TYPE_OF_ID, \
     DATASET_RESOURCE_TYPE_ID, DATASOURCE_RESOURCE_TYPE_ID, HAS_A_ID, OWNED_BY_ID
 
-PREDICATE_REFERENCE_TYPE = object_utils.create_type_identifier(object_id=25, version=1)
+from ion.integration.ais.common.ais_utils import AIS_Mixin
+
 
 #
 # Common Metadata Constants
@@ -76,7 +77,7 @@ UPDATE_INTERVAL_SECONDS = 'update_interval_seconds'
 VISUALIZATION_URL = 'visualization_url'
 VISIBILITY = 'visibility'
 
-class MetadataCache(object):
+class MetadataCache(AIS_Mixin):
     
     __metadata = {}
 
@@ -129,7 +130,7 @@ class MetadataCache(object):
         log.debug('loadDataSets()')
 
         # Get the list of dataset resource IDs
-        dSetResults = yield self.__findResourcesOfType(DATASET_RESOURCE_TYPE_ID)
+        dSetResults = yield self.findResourcesOfType(DATASET_RESOURCE_TYPE_ID)
         if dSetResults == None:
             log.error('Error finding dataset resources.')
             defer.returnValue(False)
@@ -162,7 +163,7 @@ class MetadataCache(object):
         log.debug('loadDataSources()')
         
         # Get the list of datasource resource IDs
-        dSourceResults = yield self.__findResourcesOfType(DATASOURCE_RESOURCE_TYPE_ID)
+        dSourceResults = yield self.findResourcesOfType(DATASOURCE_RESOURCE_TYPE_ID)
         if dSourceResults == None:
             log.error('Error finding datasource resources.')
             defer.returnValue(False)
@@ -422,87 +423,6 @@ class MetadataCache(object):
         defer.returnValue(returnValue)
 
 
-    @defer.inlineCallbacks
-    def getAssociatedSource(self, dSetID):
-        """
-        Worker class private method to get the data source that associated
-        with a given data set.  
-        """
-
-        if dSetID is None:
-            log.error('getAssociatedSource: dSetID is None')
-            defer.returnValue(None)
-
-        log.debug('getAssociatedSource for dSetID %s' %(dSetID))
-
-        qmsg = yield self.mc.create_instance(PREDICATE_OBJECT_QUERY_TYPE)
-        pair = qmsg.pairs.add()
-        pair.object = qmsg.CreateObject(IDREF_TYPE)
-        pair.object.key = dSetID
-        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pair.predicate.key = HAS_A_ID
-
-        pair = qmsg.pairs.add()
-        pair.object = qmsg.CreateObject(IDREF_TYPE)
-        pair.object.key = DATASOURCE_RESOURCE_TYPE_ID
-        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pair.predicate.key = TYPE_OF_ID
-        try:
-            results = yield self.asc.get_subjects(qmsg)
-        except:
-            log.exception('Error getting associated data source for Dataset: %s' % dSetID)
-            defer.returnValue(None)
-
-        dsrcs = [str(x.key) for x in results.idrefs]
-
-        # we expect one:
-        if len(dsrcs) != 1:
-            log.error('Expected 1 datasource, got %d' % len(dsrcs))
-            defer.returnValue(None)
-
-        log.debug('getAssociatedSource() exit: returning: %s' % dsrcs[0])
-
-        defer.returnValue(dsrcs[0])
-
-    @defer.inlineCallbacks
-    def getAssociatedDatasets(self, dSource):
-        """
-        Worker class private method to get the data sets that associated
-        with a given data source.  
-        """
-        log.debug('getAssociatedDatasets() entry')
-        
-        dSetList = []
-
-        if dSource is None:
-            log.error('getAssociatedDatasets: dSource parameter is None')
-            defer.returnValue(dSetList)
-
-        qmsg = yield self.mc.create_instance(ASSOCIATION_GET_STAR_MSG_TYPE)
-        pair = qmsg.subject_pairs.add()
-        pair.subject = qmsg.CreateObject(IDREF_TYPE)
-        pair.subject.key = dSource.ResourceIdentity
-        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pair.predicate.key = HAS_A_ID
-
-        pair = qmsg.object_pairs.add()
-        pair.object = qmsg.CreateObject(IDREF_TYPE)
-        pair.object.key = DATASET_RESOURCE_TYPE_ID
-        pair.predicate = qmsg.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pair.predicate.key = TYPE_OF_ID
-        try:
-            results = yield self.asc.get_star(qmsg)
-        except:
-            log.error('Error getting associated data sets for Datasource: ' + \
-                      dSource.ResourceIdentity)
-            defer.returnValue([])
-
-        dsets = [str(x.key) for x in results.idrefs]
-
-        log.info('Datasource %s has %d associated datasets.' %(dSource.ResourceIdentity, len(dsets)))
-        log.debug('getAssociatedDatasets) exit: returning: %s' %(str(dsets)))
-
-        defer.returnValue(dsets)
 
 
     @defer.inlineCallbacks
@@ -585,7 +505,7 @@ class MetadataCache(object):
             dSetMetadata[DSET] = dSet
             dSetMetadata[DSOURCE_ID] = yield self.getAssociatedSource(dSet.ResourceIdentity)
             dSetMetadata[RESOURCE_ID] = dSet.ResourceIdentity
-            dSetMetadata[OWNER_ID] = yield self.__getAssociatedOwner(dSet.ResourceIdentity)
+            dSetMetadata[OWNER_ID] = yield self.getAssociatedOwner(dSet.ResourceIdentity)
             for attrib in dSet.root_group.attributes:
                 #log.debug('Root Attribute: %s = %s'  % (str(attrib.name), str(attrib.GetValue())))
                 if attrib.name == TITLE:
@@ -682,93 +602,7 @@ class MetadataCache(object):
         else:
             log.info('data source %s is not ACTIVE: Not caching.' %(dSource.ResourceIdentity))
 
-                
 
-    @defer.inlineCallbacks
-    def __findResourcesOfType(self, resourceType):
-        """
-        A utility method to find all resources of the given type (resourceType).
-        """
-
-        request = yield self.mc.create_instance(PREDICATE_OBJECT_QUERY_TYPE)
-
-        #
-        # Set up a resource type search term using:
-        # - TYPE_OF_ID as predicate
-        # - object of type: resourceType parameter as object
-        #
-        pair = request.pairs.add()
-    
-        # ..(predicate)
-        pref = request.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pref.key = TYPE_OF_ID
-
-        pair.predicate = pref
-
-        # ..(object)
-        type_ref = request.CreateObject(IDREF_TYPE)
-        type_ref.key = resourceType
-        
-        pair.object = type_ref
-
-        try:
-            result = yield self.asc.get_subjects(request)
-
-        except AssociationServiceError:
-            log.error('__findResourcesOfType: association error!')
-            defer.returnValue(None)
-
-        defer.returnValue(result)
-
-
-    @defer.inlineCallbacks
-    def __getAssociatedOwner(self, dsID):
-        """
-        Worker class method to find the owner associated with a data set.
-        This is a public method because it can be called from the
-        findDataResourceDetail worker class.
-        """
-        log.debug('getAssociatedOwner() entry')
-
-        request = yield self.mc.create_instance(SUBJECT_PREDICATE_QUERY_TYPE)
-
-        #
-        # Set up an owned_by_id search term using:
-        # - OWNED_BY_ID as predicate
-        # - LCS_REFERENCE_TYPE object set to ACTIVE as object
-        #
-        pair = request.pairs.add()
-
-        # ..(predicate)
-        pref = request.CreateObject(PREDICATE_REFERENCE_TYPE)
-        pref.key = OWNED_BY_ID
-
-        pair.predicate = pref
-
-        # ..(subject)
-        type_ref = request.CreateObject(IDREF_TYPE)
-        type_ref.key = dsID
-        
-        pair.subject = type_ref
-
-        log.info('Calling get_objects with dsID: ' + dsID)
-
-        try:
-            result = yield self.asc.get_objects(request)
-        
-        except AssociationServiceError:
-            log.error('getAssociatedOwner: association error!')
-            defer.returnValue(None)
-
-        if len(result.idrefs) == 0:
-            log.error('Owner not found!')
-            defer.returnValue('OWNER NOT FOUND!')
-        elif len(result.idrefs) == 1:
-            log.debug('getAssociatedOwner() exit')
-            defer.returnValue(result.idrefs[0].key)
-        else:
-            log.error('More than 1 owner found!')
-            defer.returnValue('MULTIPLE OWNERS!')
 
 
     def __printMetadata(self, resType, res):

--- a/ion/integration/ais/createDownloadURL/createDownloadURL.py
+++ b/ion/integration/ais/createDownloadURL/createDownloadURL.py
@@ -33,7 +33,7 @@ class CreateDownloadURL(object):
         log.info('CreateDownloadURL.__init__()')
         self.rc = ais.rc
         self.mc = ais.mc
-        self.dscc = DatasetControllerClient(ais)
+        #self.dscc = DatasetControllerClient(ais)
 
     @defer.inlineCallbacks
     def createDownloadURL(self, msg):

--- a/ion/integration/ais/createDownloadURL/createDownloadURL.py
+++ b/ion/integration/ais/createDownloadURL/createDownloadURL.py
@@ -31,9 +31,9 @@ class CreateDownloadURL(object):
 
     def __init__(self, ais):
         log.info('CreateDownloadURL.__init__()')
-        self.rc = ResourceClient()
+        self.rc = ais.rc
         self.mc = ais.mc
-        self.dscc = DatasetControllerClient()
+        self.dscc = DatasetControllerClient(ais)
 
     @defer.inlineCallbacks
     def createDownloadURL(self, msg):

--- a/ion/integration/ais/findDataResources/findDataResources.py
+++ b/ion/integration/ais/findDataResources/findDataResources.py
@@ -193,7 +193,7 @@ class FindDataResources(object):
     PRIVATE = 0
     PUBLIC = 1
     
-    def __init__(self, ais):
+    def __init__(self, ais, metadataCache):
         log.info('FindDataResources.__init__()')
         self.ais = ais
         self.rc = ais.rc
@@ -203,7 +203,8 @@ class FindDataResources(object):
         self.nac = NotificationAlertServiceClient(proc=ais)
 
         self.__subscriptionList = None
-        self.metadataCache = ais.getMetadataCache()
+
+        self.metadataCache = metadataCache
 
     @defer.inlineCallbacks
     def findDataResources(self, msg):

--- a/ion/integration/ais/getDataResourceDetail/getDataResourceDetail.py
+++ b/ion/integration/ais/getDataResourceDetail/getDataResourceDetail.py
@@ -15,11 +15,7 @@ from ion.core.object import object_utils
 from ion.core.exception import ReceivedApplicationError
 from ion.services.coi.identity_registry import IdentityRegistryClient
 from ion.services.coi.resource_registry.resource_client import ResourceClient
-#from ion.services.dm.inventory.dataset_controller import DatasetControllerClient
-#from ion.integration.ais.getDataResourceDetail.cfdata import cfData
 
-# Temporary, until assocation of dataset and datasource are there.
-from ion.integration.ais.findDataResources.findDataResources import FindDataResources
 
 # import GPB type identifiers for AIS
 from ion.integration.ais.ais_object_identifiers import AIS_REQUEST_MSG_TYPE, \
@@ -36,7 +32,7 @@ class GetDataResourceDetail(object):
     def __init__(self, ais):
         log.info('GetDataResourceDetail.__init__()')
         self.ais = ais
-        self.rc = ResourceClient(proc=ais)
+        self.rc = ais.rc
         self.mc = ais.mc
         self.irc = IdentityRegistryClient(proc=ais)
         self.metadataCache = ais.getMetadataCache()
@@ -116,17 +112,10 @@ class GetDataResourceDetail(object):
                 RspMsg.error_str = 'AIS.getDataResourceDetail: Error calling RR.get_instance: '+ex.msg_content.MessageResponseBody
                 defer.returnValue(RspMsg)
 
-            #
-            # Find the datasource associated with this dataset, and then find the
-            # owner associated with the dataset; for now, instantiate
-            # a FindDataResources worker object. The getAssociatedSource should be
-            # moved into a common worker class; it's currently in the FindDataResources
-            # class, which doesn't use it.
-            #
+
             log.debug('getDataResourceDetail getting datasource resource instance')
-            worker = FindDataResources(self.ais)
-            dSourceResID = yield worker.getAssociatedSource(dSetResID)
-            ownerID = yield worker.getAssociatedOwner(dSetResID)
+            dSourceResID = yield self.ais.getAssociatedSource(dSetResID)
+            ownerID = yield self.ais.getAssociatedOwner(dSetResID)
         
         log.debug('ownerID: ' + ownerID + ' owns dataSetID: ' + dSetResID)
         userProfile = yield self.__getUserProfile(ownerID)

--- a/ion/integration/ais/getDataResourceDetail/getDataResourceDetail.py
+++ b/ion/integration/ais/getDataResourceDetail/getDataResourceDetail.py
@@ -29,13 +29,13 @@ RESOURCE_CFG_REQUEST_TYPE = object_utils.create_type_identifier(object_id=10, ve
 
 class GetDataResourceDetail(object):
     
-    def __init__(self, ais):
+    def __init__(self, ais, metadataCache):
         log.info('GetDataResourceDetail.__init__()')
         self.ais = ais
         self.rc = ais.rc
         self.mc = ais.mc
         self.irc = IdentityRegistryClient(proc=ais)
-        self.metadataCache = ais.getMetadataCache()
+        self.metadataCache = metadataCache
         self.bUseMetadataCache = True
 
         

--- a/ion/integration/ais/manage_data_resource/manage_data_resource.py
+++ b/ion/integration/ais/manage_data_resource/manage_data_resource.py
@@ -75,12 +75,6 @@ DEFAULT_MAX_INGEST_MILLIS = 30000
 class ManageDataResource(object):
 
     def __init__(self, ais):
-
-        # Isolate teh Data Resource Manager in a separate process from the metadata cache
-        ais = Process(**{'proc-name':'ManagDataResource Process'})
-        ais.spawn()
-        ais.mc = ais.message_client
-        ais.rc = ResourceClient(ais)
         
         log.debug('ManageDataResource.__init__()')
         self._proc = ais
@@ -96,7 +90,7 @@ class ManageDataResource(object):
         #self.ing   = IngestionClient(proc=ais)
         self.nac   = NotificationAlertServiceClient(proc=ais)
          
-        #necessary to receive events i think
+        #necessary to publish events
         self.pub_schd   = ScheduleEventPublisher(process=ais)
         self.pub_dsrc   = DatasourceChangeEventPublisher(process=ais)
 

--- a/ion/integration/ais/manage_data_resource_subscription/manage_data_resource_subscription.py
+++ b/ion/integration/ais/manage_data_resource_subscription/manage_data_resource_subscription.py
@@ -104,8 +104,6 @@ class ManageDataResourceSubscription(object):
         self.pfd = None
 
         self.nac = NotificationAlertServiceClient(proc=ais)
-        self.metadataCache = ais.getMetadataCache()
- 
 
     @defer.inlineCallbacks
     def update(self, msg):
@@ -625,7 +623,7 @@ class ManageDataResourceSubscription(object):
         j = 0
         for result in reply.message_parameters_reference[0].subscriptionListResults:
             dSetResID = result.datasetMetadata.data_resource_id
-            dSetMetadata = yield self.metadataCache.getDSetMetadata(dSetResID)
+            dSetMetadata = yield self.ais.getDSetMetadata(dSetResID)
             if dSetMetadata is None:
                 log.error('Metadata not found for dataset: %s' %(dSetResID))
             else:

--- a/ion/integration/ais/manage_data_resource_subscription/manage_data_resource_subscription.py
+++ b/ion/integration/ais/manage_data_resource_subscription/manage_data_resource_subscription.py
@@ -87,7 +87,7 @@ message ResourceConfigurationResponse{
 
 class ManageDataResourceSubscription(object):
 
-    def __init__(self, ais):
+    def __init__(self, ais, metadata_cache):
         log.debug('ManageDataResourceSubscription.__init__()')
         self.mc  = ais.mc
         self.rc  = ais.rc
@@ -104,6 +104,8 @@ class ManageDataResourceSubscription(object):
         self.pfd = None
 
         self.nac = NotificationAlertServiceClient(proc=ais)
+
+        self.metadata_cache = metadata_cache
 
     @defer.inlineCallbacks
     def update(self, msg):
@@ -623,7 +625,7 @@ class ManageDataResourceSubscription(object):
         j = 0
         for result in reply.message_parameters_reference[0].subscriptionListResults:
             dSetResID = result.datasetMetadata.data_resource_id
-            dSetMetadata = yield self.ais.getDSetMetadata(dSetResID)
+            dSetMetadata = yield self.metadata_cache.getDSetMetadata(dSetResID)
             if dSetMetadata is None:
                 log.error('Metadata not found for dataset: %s' %(dSetResID))
             else:

--- a/ion/integration/ais/test/test_manage_data_resource.py
+++ b/ion/integration/ais/test/test_manage_data_resource.py
@@ -150,15 +150,6 @@ class AISManageDataResourceTest(IonTestCase):
         self.ac    = AssociationClient(proc=proc)
 
 
-        ### Test should now pass with the cache on!
-        #prepare to monkey patch so we don't use the cache functions
-        #child_aiss = yield self.sup.get_child_id('app_integration')
-        #self.aiss  = self._get_procinstance(child_aiss)
-
-        # For testing purposes - turn of the subscriber and remove the call back to update the cache - for now!
-        #self.aiss.dataset_subscriber.terminate()
-        #self.aiss.datasource_subscriber.terminate()
-
     @defer.inlineCallbacks
     def tearDown(self):
         log.info('Tearing Down Test Container')

--- a/ion/integration/ais/test/test_metadata_cache.py
+++ b/ion/integration/ais/test/test_metadata_cache.py
@@ -65,9 +65,7 @@ class MetadataCacheTest(IonTestCase, AIS_Mixin):
         
     @defer.inlineCallbacks
     def setUp(self):
-        log.debug('AppIntegrationTest.setUp(): waiting for any update events to clear...')
-
-        yield pu.asleep(0.5)
+        log.debug('AppIntegrationTest.setUp():')
 
         yield self._start_container()
         
@@ -124,11 +122,6 @@ class MetadataCacheTest(IonTestCase, AIS_Mixin):
         yield self.cache.loadDataSources()
 
         self.subproc = subproc
-
-        if self.AnalyzeTiming != None:
-            self.TimeStamps.StartTime = time.time()
-            self.TimeStamps.LastTime = self.TimeStamps.StartTime
-
 
         # Setup the publishers
         datasetPublisher = DatasetChangeEventPublisher(process=self.publisher_proc)

--- a/ion/integration/ais/test/test_metadata_cache.py
+++ b/ion/integration/ais/test/test_metadata_cache.py
@@ -12,7 +12,9 @@ import ion.util.procutils as pu
 
 from twisted.internet import defer
 import time
-    
+
+
+from ion.integration.ais.common.ais_utils import AIS_Mixin
 from ion.core.process.process import Process
 from ion.core.object import object_utils
 from ion.core.messaging.message_client import MessageClient
@@ -51,7 +53,7 @@ TEST_RESOURCE_ID = '01234567-8abc-def0-1234-567890123456'
 DISPATCHER_RESOURCE_TYPE = object_utils.create_type_identifier(object_id=7002, version=1)
 
 
-class MetadataCacheTest(IonTestCase):
+class MetadataCacheTest(IonTestCase, AIS_Mixin):
    
     """
     Testing Metadata Cache.
@@ -59,28 +61,14 @@ class MetadataCacheTest(IonTestCase):
 
     # Set timeout for Trial tests
     timeout = 40
-    
-    # set to None to turn off timing logging, set to anything else to turn on timing logging
-    AnalyzeTiming = None
-    
-    class TimeStampsClass (object):
-        pass
-    
-    TimeStamps = TimeStampsClass()
-    
-    def TimeStamp (self):
-        TimeNow = time.time()
-        TimeStampStr = "(wall time = " + str (TimeNow) + \
-                       ", elapse time = " + str(TimeNow - self.TimeStamps.StartTime) + \
-                       ", delta time = " + str(TimeNow - self.TimeStamps.LastTime) + \
-                       ")"
-        self.TimeStamps.LastTime = TimeNow
-        return TimeStampStr
-    
+
         
     @defer.inlineCallbacks
     def setUp(self):
-        log.debug('AppIntegrationTest.setUp():')
+        log.debug('AppIntegrationTest.setUp(): waiting for any update events to clear...')
+
+        yield pu.asleep(0.5)
+
         yield self._start_container()
         
         services = [
@@ -174,9 +162,6 @@ class MetadataCacheTest(IonTestCase):
         yield self._shutdown_processes()
         yield self._stop_container()
 
-    def getMetadataCache(self):
-        return self.cache
-
     @defer.inlineCallbacks
     def test_metadataCache(self):
         log.debug('Testing updateMetadataCache.')
@@ -222,6 +207,8 @@ class MetadataCacheTest(IonTestCase):
 
         dsourcelist = self.cache.getDataSources()
         for ds in dsourcelist:
+
+            print 'DKLS KLSD DSKLD LKS DSLNFLSKDNFIOFHLBLJSKDB   KLSNDKLSN'
             dSourceResID = ds['dsource'].ResourceIdentity
 
             dSourceMetadata = yield self.cache.getDSourceMetadata(dSourceResID)

--- a/ion/integration/ais/test/test_metadata_cache.py
+++ b/ion/integration/ais/test/test_metadata_cache.py
@@ -201,7 +201,6 @@ class MetadataCacheTest(IonTestCase, AIS_Mixin):
         dsourcelist = self.cache.getDataSources()
         for ds in dsourcelist:
 
-            print 'DKLS KLSD DSKLD LKS DSLNFLSKDNFIOFHLBLJSKDB   KLSNDKLSN'
             dSourceResID = ds['dsource'].ResourceIdentity
 
             dSourceMetadata = yield self.cache.getDSourceMetadata(dSourceResID)


### PR DESCRIPTION
Refactored AIS to use a separate process for the metadata cache and data set/source subscribers to avoid race conditions in operating on resources. 
Also factored out a number of common methods for use in multiple places by AIS workers.
