### PR TITLE
Truncate commits

### DIFF
--- a/ion/core/object/repository.py
+++ b/ion/core/object/repository.py
@@ -1244,9 +1244,8 @@ class Repository(ObjectContainer):
 
                         old_commit_keys.remove(parent.MyId)
 
-
             commits_front = new_front
-            new_front = new_front.clear()
+            new_front = set()
 
         for key in old_commit_keys:
 

--- a/ion/core/object/repository.py
+++ b/ion/core/object/repository.py
@@ -1259,6 +1259,8 @@ class Repository(ObjectContainer):
 
         for key in old_commit_keys:
 
+            cref = self._commit_index[key]
+            cref.Invalidate()
             del self._commit_index[key]
             del self.index_hash[key]
 

--- a/ion/core/object/workbench.py
+++ b/ion/core/object/workbench.py
@@ -1011,40 +1011,6 @@ class WorkBench(object):
         The return value is a list of binary SHA1 keys
         """
 
-        '''
-        if repo.status == repo.MODIFIED:
-            log.warn('Automatic commit called during pull. Commit should be called first!')
-            comment='Commiting to send message with wrapper object'
-            repo.commit(comment=comment)
-        '''
-
-        '''
-        cref_set = set()
-        for branch in repo.branches:
-
-            for cref in branch.commitrefs:
-                cref_set.add(cref)
-
-        key_set = set()
-
-        while len(cref_set)>0:
-            new_set = set()
-
-            for cref in cref_set:
-
-                if cref.MyId not in key_set:
-                    key_set.add(cref.MyId)
-
-                    for prefs in cref.parentrefs:
-                        new_set.add(prefs.commitref)
-
-
-            # Now recurse on the ancestors
-            cref_set = new_set
-
-        key_list = []
-        key_list.extend(key_set)
-        '''
 
         # Just use the commit index dictionary...
         key_list = repo._commit_index.keys()
@@ -1058,12 +1024,7 @@ class WorkBench(object):
 
         The method is a bit trivial - candidate for removal!
         """
-        '''
-        if repo.status == repo.MODIFIED:
-            log.warn('Automatic commit called during push. Commit should be called first!')
-            comment='Commiting to push repo.'
-            repo.commit(comment=comment)
-        '''
+
 
         return repo.index_hash.keys()
 

--- a/ion/core/object/workbench.py
+++ b/ion/core/object/workbench.py
@@ -1172,6 +1172,8 @@ class WorkBench(object):
                             log.debug('Commit history is truncated... found oldest commit')
                             break
 
+                    log.warn('REPO (%s) Branch Syncing: newest existing commit date - %s, oldest new commit date - %s, new commit ref count - %d ' % (repo.repository_key, existing_cref.date, pref.date, cref_count))
+
                     if pref.date > existing_cref.date and cref_count > 10:
                         # If all these new commits - and there better be at least 10 of them... are newer than the newest
                         # existing commit - assume that it is not a merge but just a gap in the history!

--- a/ion/core/object/workbench.py
+++ b/ion/core/object/workbench.py
@@ -1067,6 +1067,8 @@ class WorkBench(object):
 
             head.Invalidate()
 
+        repo.truncate_commits()
+
             
         return
 

--- a/ion/services/coi/datastore.py
+++ b/ion/services/coi/datastore.py
@@ -560,7 +560,7 @@ class DataStoreWorkbench(WorkBench):
             new_head.MyId = repo.new_id()
 
             # Now merge the state!
-            self._update_repo_to_head(repo,new_head)
+            self._update_repo_to_head(repo,new_head, truncate_commits=False)
 
         # Put any new blobs
         def_list = []

--- a/ion/services/coi/test/test_datastore.py
+++ b/ion/services/coi/test/test_datastore.py
@@ -813,6 +813,35 @@ class DataStoreTest(IonTestCase):
 
 
 
+    def create_many_commits(self,repo, number):
+
+        for n in range(number):
+            repo.root_object.title = 'WB Title Commit: %s' % str(n)
+            repo.commit('repo %s commit' % str(n))
+
+        return
+
+
+    @defer.inlineCallbacks
+    def test_truncate_commits(self):
+
+        repo = self.wb1.workbench.get_repository(self.repo_key)
+
+        self.create_many_commits(repo,30)
+
+        result = yield self.wb1.workbench.push('datastore',repo)
+
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+        self.create_many_commits(repo,30)
+
+        result = yield self.wb1.workbench.push('datastore',repo)
+
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+
+
+
 class MulitDataStoreTest(IonTestCase):
     """
     Testing Datastore service.

--- a/ion/services/coi/test/test_datastore.py
+++ b/ion/services/coi/test/test_datastore.py
@@ -12,6 +12,8 @@ from ion.core.messaging.receiver import Receiver, WorkerReceiver
 from ion.core.process.process import Process
 from ion.core.object.object_utils import ARRAY_STRUCTURE_TYPE, CDM_ARRAY_FLOAT64_TYPE, CDM_ARRAY_FLOAT32_TYPE, CDM_ARRAY_FLOAT32_TYPE, CDM_ATTRIBUTE_TYPE
 
+from ion.core.object.test.test_workbench import WorkBenchProcess
+
 import ion.util.ionlog
 
 log = ion.util.ionlog.getLogger(__name__)
@@ -825,19 +827,56 @@ class DataStoreTest(IonTestCase):
     @defer.inlineCallbacks
     def test_truncate_commits(self):
 
+        log.info('Create 30 commits and push to datastore')
         repo = self.wb1.workbench.get_repository(self.repo_key)
-
         self.create_many_commits(repo,30)
-
         result = yield self.wb1.workbench.push('datastore',repo)
-
         self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
 
+
+        log.info('Create 30 more commits and push to datastore')
         self.create_many_commits(repo,30)
-
         result = yield self.wb1.workbench.push('datastore',repo)
-
         self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+
+        log.info('Create a new workbench process and pull from datastore')
+        wb2 = WorkBenchProcess()
+        yield wb2.spawn()
+
+        result = yield wb2.workbench.pull('datastore', self.repo_key)
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+        repo2 = wb2.workbench.get_repository(self.repo_key)
+        yield repo2.checkout('master')
+
+        log.info('Create 61 commits and push to datastore from workbench 2')
+        self.create_many_commits(repo2,61)
+        # Test pushing more than the default number to truncate...
+        result = yield wb2.workbench.push('datastore',repo2)
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+
+        self.assertEqual(len(repo2._commit_index),111)
+
+
+
+        log.info('Pull it back to wb2 again - to clear the number of commits')
+        result = yield wb2.workbench.pull('datastore', self.repo_key)
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+        repo2 = wb2.workbench.get_repository(self.repo_key)
+        yield repo2.checkout('master')
+
+
+
+        log.info('Pull it all back to workbench 1...')
+        # Now pull it back to the original...
+        result = yield self.wb1.workbench.pull('datastore', self.repo_key)
+        self.assertEqual(result.MessageResponseCode, result.ResponseCodes.OK)
+
+        repo = self.wb1.workbench.get_repository(self.repo_key)
+        yield repo.checkout('master')
 
 
 


### PR DESCRIPTION
Added a truncate commits method - which defaults to 50 commits. This work bench/datastore has been modified to reason over the partial graph of the commit history rather than assuming the full history is always present. The truncate method is always and automatically called whenever a local repository is synchronized with a remote source - either the cassandra DB or a remote service doing a push/pull operation. This is a big improvement as it will prevent each service from carrying the complete history of a repository which extends into the thousands for data sets that update frequently.
