### PR TITLE
Truncate bugs

### DIFF
--- a/ion/core/data/cassandra.py
+++ b/ion/core/data/cassandra.py
@@ -134,7 +134,8 @@ class QueryStats(object):
         return tuple(stats)
 
 
-cassandra_timeout = CONF.getValue('CassandraTimeout',10.0)
+# Don't let cassandra timeout cause failure
+cassandra_timeout = CONF.getValue('CassandraTimeout',60.0)
 class CassandraError(Exception):
     """
     An exception class for ION Cassandra Client errors

--- a/ion/core/object/repository.py
+++ b/ion/core/object/repository.py
@@ -1259,12 +1259,21 @@ class Repository(ObjectContainer):
             commits_front = new_front
             new_front = set()
 
+        # Remove the old keys - truncating the local history
         for key in old_commit_keys:
 
             cref = self._commit_index[key]
             cref.Invalidate()
             del self._commit_index[key]
             del self.index_hash[key]
+
+        # Clean up any parent refs left behind Bug OOIION-510
+        for cref in self._commit_index.itervalues():
+
+            for plink in cref.ParentLinks.copy():
+
+                if plink.Invalid:
+                    cref.ParentLinks.discard(plink)
 
         log.info('Truncate Commits - Complete!')
 

--- a/ion/ops/resources.py
+++ b/ion/ops/resources.py
@@ -319,11 +319,17 @@ def print_dataset_history(dsid):
         else:
             cref = None
 
+    try:
+        title = commits[0].objectroot.resource_object.root_group.FindAttributeByName('title').GetValue()
+    except:
+        title = "(no title found)"
+
     # parent -> child ordering
     commits.reverse()
 
     outlines.append('========= Dataset History: ==========')
     outlines.append('= Dataset ID: %s' % repo.repository_key)
+    outlines.append('= Dataset Title: %s' % title)
     outlines.append('= Dataset Branch: %s' % repo.current_branch_key())
 
     for i, c in enumerate(commits):

--- a/ion/ops/resources.py
+++ b/ion/ops/resources.py
@@ -315,7 +315,11 @@ def print_dataset_history(dsid):
         commits.append(cref)
 
         if cref.parentrefs:
-            cref = cref.parentrefs[0].commitref
+            try:
+                cref = cref.parentrefs[0].commitref
+            except KeyError:
+                log.info('Commit history was truncated!')
+                cref = None
         else:
             cref = None
 


### PR DESCRIPTION
Fix for bug OOIION-510.
In certain edge cases the truncate commits method must clean up parent links that are invalidated.
Also fixed some issues with truncate commits in the print_dataset_history method of ops.resources.
Changed the default timeout for cassandra operations to 60 seconds (instead of 10).

The last change should increase the stability of the datastore. Letting the service operation timeout is better than forcing an error return from a cassandra operation taking too long. That way the process will complete what it is doing.
