### PR TITLE
Batch update

### DIFF
--- a/ion/core/data/cassandra.py
+++ b/ion/core/data/cassandra.py
@@ -344,7 +344,7 @@ class CassandraBatchRequest(SimpleBatchRequest):
         self._br = {}
 
     @defer.inlineCallbacks
-    def add_request(self,key, value, index_attributes=None):
+    def add_request(self,key, value=None, index_attributes=None):
         """
         @param key The key to the Cassandra row
         @param value The value of the value column in the Cassandra row
@@ -359,9 +359,10 @@ class CassandraBatchRequest(SimpleBatchRequest):
         #log.info("Put: index_attributes %s" % (index_cols))
         yield self.index_client._check_index(index_cols)
 
-        columns = {"value":value, "has_key":"1"}
+        if value is not None:
+            columns = {"value":value, "has_key":"1"}
 
-        index_cols.update(columns)
+            index_cols.update(columns)
 
         self._br[key] = {self.index_client._cache_name:index_cols}
 
@@ -458,8 +459,6 @@ class CassandraIndexedStore(CassandraStore):
 
         assert isinstance(batch_request, CassandraBatchRequest), 'IndexStore batch_put method takes a BatchRequest object, got type: %s' % type(batch_request)
 
-        import pprint
-        pprint.pprint(batch_request._br)
         yield self.client.batch_mutate(batch_request._br)
 
 

--- a/ion/core/data/cassandra.py
+++ b/ion/core/data/cassandra.py
@@ -142,6 +142,48 @@ class CassandraError(Exception):
     """
 
 
+class CassandraBatchRequest(SimpleBatchRequest):
+
+
+    def __init__(self, index_client=None):
+
+
+        # @TODO make sure that this is an instance of an IndexStore
+        self.index_client = index_client
+
+        self._br = {}
+
+    @defer.inlineCallbacks
+    def add_request(self,key, value=None, index_attributes=None):
+        """
+        @param key The key to the Cassandra row
+        @param value The value of the value column in the Cassandra row
+        @param index_attributes The dictionary contains keys for the column name and the index value
+        """
+
+
+
+        if index_attributes is None:
+            index_cols = {}
+        else:
+            index_cols = dict(**index_attributes)
+
+        if self.index_client is not None and isinstance(self.index_client, CassandraIndexedStore):
+            yield self.index_client._check_index(index_cols)
+
+        if value is not None:
+            columns = {"value":value, "has_key":"1"}
+
+            index_cols.update(columns)
+
+        self._br[key] = {self.index_client._cache_name:index_cols}
+
+        defer.returnValue(True)
+
+    def __len__(self):
+        return len(self._br)
+
+
     
 class CassandraStore(TCPConnection):
     """
@@ -164,8 +206,13 @@ class CassandraStore(TCPConnection):
     implements(store.IStore)
 
     put_stats = SizeStats()
+    batch_put_stats = SizeStats()
+
     get_stats = SizeStats()
+    batch_get_stats = SizeStats()
+
     has_stats = SizeStats()
+    batch_has_stats = SizeStats()
 
     stats_out = 10000
 
@@ -200,7 +247,12 @@ class CassandraStore(TCPConnection):
         log.info("leaving __init__")
 
 
+    def new_batch_request(self):
+
+        return CassandraBatchRequest(self)
+
     get_stats_string = 'Cassandra Store Get Stats(%d ops): time seconds (mean/mean per Kb/max) %f/%f/%f; size (mean/max) %f/%f Kb, Not Found - %d;'
+
     @timeout(cassandra_timeout)
     @defer.inlineCallbacks
     def get(self, key):
@@ -238,6 +290,50 @@ class CassandraStore(TCPConnection):
 
         defer.returnValue(value)
 
+    batch_get_stats_string = 'Cassandra Store Batch Get Stats(%d ops): time seconds (mean/mean per Kb/max) %f/%f/%f; size (mean/max) %f/%f Kb, Not Found - %d;'
+
+
+    @timeout(cassandra_timeout)
+    @defer.inlineCallbacks
+    def batch_get(self, batch_request):
+        """
+        @brief Return a dictionary of values corresponding to a given batch of keys
+        @param key
+        @retval Deferred that fires with the value of key
+        """
+
+        #log.debug("CassandraStore: Calling get on key %s " % key)
+
+        tic = time.time()
+        lval = 0
+
+        assert isinstance(batch_request, CassandraBatchRequest), 'CassandraStore batch_put method takes a BatchRequest object, got type: %s' % type(batch_request)
+
+        result = yield self.client.multiget(batch_request._br.keys(), self._cache_name, column='value')
+
+        batch = {}
+        for key, columns in result.iteritems():
+            if len(columns) is 1:
+                batch[key] = columns[0].column.value
+            else:
+                batch[key] = None
+
+        lval = len(batch)
+        toc = time.time()
+
+
+        if toc - tic > 4.0:
+            log.info('Cassandra batch get operation elapsed time %f; result size: %s' % (toc - tic, lval))
+
+        self.batch_get_stats.add_stats(tic,toc,lval)
+
+        if self.batch_get_stats.t_count >= self.stats_out:
+            log.critical(self.batch_get_stats_string % self.batch_get_stats.get_stats())
+            self.batch_get_stats.__init__()
+
+        defer.returnValue(batch)
+
+
     @timeout(cassandra_timeout)
     @defer.inlineCallbacks
     def put(self, key, value):
@@ -267,6 +363,36 @@ class CassandraStore(TCPConnection):
             log.critical('Cassandra Store Put Stats(%d ops): time seconds (mean/mean per Kb/max) %f/%f/%f; size (mean/max) %f/%f Kb;' % self.put_stats.put_stats())
             self.put_stats.__init__()
 
+    @timeout(cassandra_timeout)
+    @defer.inlineCallbacks
+    def batch_put(self, batch_request):
+        """
+        Istore batch_put for indexed stuff in cassandra
+
+        @param batch_request is a batch request object containing one or more keys to put
+        """
+
+        tic = time.time()
+
+        assert isinstance(batch_request, CassandraBatchRequest), 'CassandraStore batch_put method takes a BatchRequest object, got type: %s' % type(batch_request)
+
+        yield self.client.batch_mutate(batch_request._br)
+
+
+        toc = time.time()
+
+        if toc - tic > 4.0:
+            log.warn('Cassandra batch_put operation elapsed time %f; result size: %s' % (toc - tic, len(batch_request)))
+
+        self.batch_put_stats.add_stats(tic,toc,len(batch_request))
+
+        if self.batch_put_stats.t_count >= self.stats_out:
+            log.critical('Cassandra Store Batch Put Stats(%d ops): time seconds (mean/mean per row/max) %f/%f/%f; size (mean/max) %f/%f rows;' % self.batch_put_stats.put_stats())
+            self.batch_put_stats.__init__()
+
+
+
+
     has_key_stats_string = 'Cassandra Store Has_Key Stats(%d ops): time seconds (mean/max) %f/%f;'
     @timeout(cassandra_timeout)
     @defer.inlineCallbacks
@@ -287,7 +413,7 @@ class CassandraStore(TCPConnection):
         toc = time.time()
 
         if toc - tic > 4.0:
-            log.info('Cassandra has_key operation elapsed time %f;' % (toc - tic))
+            log.info('CassandraStore has_key operation elapsed time %f;' % (toc - tic))
 
         self.has_stats.add_stats(tic,toc)
 
@@ -296,6 +422,44 @@ class CassandraStore(TCPConnection):
             self.has_stats.__init__()
 
         defer.returnValue(ret)
+
+
+    batch_has_key_stats_string = 'Cassandra Store Batch_Has_Key Stats(%d ops): time seconds (mean/max) %f/%f;'
+    @timeout(cassandra_timeout)
+    @defer.inlineCallbacks
+    def batch_has_key(self, batch_request):
+        """
+        Checks to see if the key exists in the column family
+        @param batch_request is a batch request of keys
+        @retVal Returns a dictionary of bools in a deferred
+        """
+        tic = time.time()
+
+        assert isinstance(batch_request, CassandraBatchRequest), 'CassandraStore batch_has_key method takes a BatchRequest object, got type: %s' % type(batch_request)
+
+        result = yield self.client.multiget(batch_request._br.keys(), self._cache_name, column="has_key")
+
+        batch = {}
+        for key, columns in result.iteritems():
+            if len(columns) is 1:
+                batch[key] = True
+            else:
+                batch[key] = False
+
+        toc = time.time()
+
+        if toc - tic > 4.0:
+            log.info('CassandraStore batch_has_key operation elapsed time %f;' % (toc - tic))
+
+        self.has_stats.add_stats(tic,toc)
+
+        if self.has_stats.t_count >= self.stats_out:
+            log.critical(self.batch_has_key_stats_string % self.has_stats.simple_stats())
+            self.has_stats.__init__()
+
+        defer.returnValue(batch)
+
+
 
     @timeout(cassandra_timeout)
     @defer.inlineCallbacks
@@ -330,46 +494,6 @@ class CassandraStore(TCPConnection):
     def on_activate(self, *args, **kwargs):
 
         yield TCPConnection.on_activate(self)
-
-
-class CassandraBatchRequest(SimpleBatchRequest):
-
-
-    def __init__(self, index_client):
-
-
-        # @TODO make sure that this is an instance of an IndexStore
-        self.index_client = index_client
-
-        self._br = {}
-
-    @defer.inlineCallbacks
-    def add_request(self,key, value=None, index_attributes=None):
-        """
-        @param key The key to the Cassandra row
-        @param value The value of the value column in the Cassandra row
-        @param index_attributes The dictionary contains keys for the column name and the index value
-        """
-
-        if index_attributes is None:
-            index_cols = {}
-        else:
-            index_cols = dict(**index_attributes)
-
-        #log.info("Put: index_attributes %s" % (index_cols))
-        yield self.index_client._check_index(index_cols)
-
-        if value is not None:
-            columns = {"value":value, "has_key":"1"}
-
-            index_cols.update(columns)
-
-        self._br[key] = {self.index_client._cache_name:index_cols}
-
-        defer.returnValue(True)
-
-    def __len__(self):
-        return len(self._br)
 
 
 

--- a/ion/core/data/store.py
+++ b/ion/core/data/store.py
@@ -20,6 +20,52 @@ log = ion.util.ionlog.getLogger(__name__)
 
 
 
+class IndexStoreError(Exception):
+    """
+    An exception class for the index store
+    """
+
+class SimpleBatchRequest(object):
+
+
+    def __init__(self, index_client=None):
+
+        # @TODO make sure that this is an instance of an IndexStore
+        self.index_client = index_client
+
+        self._br = {}
+
+    def add_request(self,key, value=None, index_attributes=None):
+        """
+        @param key The key to the Cassandra row
+        @param value The value of the value column in the Cassandra row
+        @param index_attributes The dictionary contains keys for the column name and the index value
+        """
+
+        if index_attributes is not None:
+
+            if self.index_client is None:
+                raise IndexStoreError('Called add_request with index_attributes for a batch object which was not created with an index store!')
+
+
+            query_attribute_names = set(self.index_client.indices.keys())
+            index_attribute_names = set(index_attributes.keys())
+
+            if not index_attribute_names.issubset(query_attribute_names):
+                bad_attrs = index_attribute_names.difference(query_attribute_names)
+                raise IndexStoreError("These attributes: %s %s %s"  % (",".join(bad_attrs),os.linesep,"are not indexed."))
+
+
+        self._br[key] = (value, index_attributes)
+
+        return defer.succeed(True)
+
+    def __len__(self):
+        return len(self._br)
+
+
+
+
 class IStore(Interface):
     """
     Interface all store backend implementations.
@@ -62,17 +108,53 @@ class Store(object):
     def __init__(self, *args, **kwargs):
         pass
 
+    def new_batch_request(self):
+
+        return SimpleBatchRequest()
+
+
     def get(self, key):
         """
         @see IStore.get
         """
         return defer.maybeDeferred(self.kvs.get, key, None)
 
+    def batch_get(self, batch_request):
+        """
+        Istore batch_put
+
+        @param batch_request is a batch request object containing one or more keys to get
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'Store batch_get method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        kv = {}
+        for key in batch_request._br.iterkeys():
+            kv[key] =  self.kvs.get(key)
+
+        return defer.succeed(kv)
+
+
     def put(self, key, value):
         """
         @see IStore.put
         """
         return defer.maybeDeferred(self.kvs.update, {key:value})
+
+    def batch_put(self, batch_request):
+        """
+        Istore batch_put
+
+        @param batch_request is a batch request object containing one or more keys & values to put
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'Store batch_put method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        batch={}
+        for key, (value, index_atts) in batch_request._br.iteritems():
+            batch[key] = value
+
+        return defer.maybeDeferred(self.kvs.update, batch)
 
     def remove(self, key):
         """
@@ -92,6 +174,22 @@ class Store(object):
         """ 
         return defer.maybeDeferred(self.kvs.has_key, key )
 
+    def batch_has_key(self, batch_request):
+        """
+        Istore batch_has_key
+
+        @param batch_request is a batch request object containing one or more keys to test
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'Store batch_has_key method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        kv = {}
+        for key in batch_request._br.iterkeys():
+            kv[key] =  self.kvs.has_key(key)
+
+        return defer.succeed(kv)
+
+
 
 class IIndexStore(IStore):
     """
@@ -105,6 +203,12 @@ class IIndexStore(IStore):
         """
         @param key  an immutable key associated with a value
         @retval Deferred, for value associated with key, or None if not existing.
+        """
+
+    def batch_get(batch_request):
+        """
+        @param batch_request is a BatchRequest object containing all the keys to get
+        @retval Deferred, dictionary of keys and value, or None if not existing.
         """
 
     def put(key, value, index_attributes=None):
@@ -149,51 +253,19 @@ class IIndexStore(IStore):
         @param key is the key to check in the column family
         @retVal Returns a bool in a deferred
         """ 
-    
+
+    def batch_has_key(batch_request):
+        """
+        Checks to see if the key exists in the column family
+        @param batch_request is a BatchRequest object containing all the keys to check in the column family
+        @retVal Returns a dictionary of key and bool in a deferred
+        """
+
+
     def get_query_attributes( ):
         """
         Return the column names that are indexed.
         """
-
-class IndexStoreError(Exception):
-    """
-    An exception class for the index store
-    """
-
-class SimpleBatchRequest(object):
-
-
-    def __init__(self, index_client):
-
-        # @TODO make sure that this is an instance of an IndexStore
-        self.index_client = index_client
-
-        self._br = {}
-
-    def add_request(self,key, value=None, index_attributes=None):
-        """
-        @param key The key to the Cassandra row
-        @param value The value of the value column in the Cassandra row
-        @param index_attributes The dictionary contains keys for the column name and the index value
-        """
-
-        query_attribute_names = set(self.index_client.indices.keys())
-        index_attribute_names = set(index_attributes.keys())
-
-        if not index_attribute_names.issubset(query_attribute_names):
-            bad_attrs = index_attribute_names.difference(query_attribute_names)
-            raise IndexStoreError("These attributes: %s %s %s"  % (",".join(bad_attrs),os.linesep,"are not indexed."))
-
-
-        self._br[key] = (value, index_attributes)
-
-        return defer.succeed(True)
-
-    def __len__(self):
-        return len(self._br)
-
-
-
 
 class IndexStore(object):
     """
@@ -237,6 +309,26 @@ class IndexStore(object):
         """
         @see IStore.get
         """
+        row = self.kvs.get(key, None)
+        if row is None:
+            return defer.succeed(None)
+        else:
+            return defer.maybeDeferred(row.get, "value")
+
+    def batch_get(self, batch_request):
+        """
+        @see IStore.batch_get
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'IndexStore batch_get method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        kv = {}
+        for key in batch_request._br.iterkeys():
+            kv[key]  =  self.kvs.get(key,{}).get('value',None)
+
+        return defer.succeed(kv)
+
+
         row = self.kvs.get(key, None)
         if row is None:
             return defer.succeed(None)
@@ -396,7 +488,23 @@ class IndexStore(object):
         @retVal Returns a bool in a deferred
         """
         return defer.maybeDeferred(self.kvs.has_key, key)
-    
+
+    def batch_has_key(self, batch_request):
+        """
+        Istore batch_has_key
+
+        @param batch_request is a batch request object containing one or more keys to test
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'IndexStore batch_has_key method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        kv = {}
+        for key in batch_request._br.iterkeys():
+            kv[key] =  self.kvs.has_key(key)
+
+        return defer.succeed(kv)
+
+
     def get_query_attributes(self):
         """
         Return the column names that are indexed.

--- a/ion/core/data/store.py
+++ b/ion/core/data/store.py
@@ -115,6 +115,13 @@ class IIndexStore(IStore):
         @param index_attributes a dictionary of attributes by which to index this value of this key
         @retval Deferred, for success of this operation
         """
+
+
+    def batch_put(batch_request):
+        """
+        @param batch_request is a BatchRequest object containing all the rows to add or update
+        @retval Deferred, for success of this operation
+        """
     
     def remove(key):
         """
@@ -153,6 +160,41 @@ class IndexStoreError(Exception):
     An exception class for the index store
     """
 
+class SimpleBatchRequest(object):
+
+
+    def __init__(self, index_client):
+
+        # @TODO make sure that this is an instance of an IndexStore
+        self.index_client = index_client
+
+        self._br = {}
+
+    def add_request(self,key, value, index_attributes=None):
+        """
+        @param key The key to the Cassandra row
+        @param value The value of the value column in the Cassandra row
+        @param index_attributes The dictionary contains keys for the column name and the index value
+        """
+
+        query_attribute_names = set(self.index_client.indices.keys())
+        index_attribute_names = set(index_attributes.keys())
+
+        if not index_attribute_names.issubset(query_attribute_names):
+            bad_attrs = index_attribute_names.difference(query_attribute_names)
+            raise IndexStoreError("These attributes: %s %s %s"  % (",".join(bad_attrs),os.linesep,"are not indexed."))
+
+
+        self._br[key] = (value, index_attributes)
+
+        return defer.succeed(True)
+
+    def __len__(self):
+        return len(self._br)
+
+
+
+
 class IndexStore(object):
     """
     Memory implementation of an asynchronous key/value store, using a dict.
@@ -185,6 +227,12 @@ class IndexStore(object):
                 if not self.indices.has_key(name):
                     self.indices[name]={}
 
+
+    def new_batch_request(self):
+
+        return SimpleBatchRequest(self)
+
+
     def get(self, key):
         """
         @see IStore.get
@@ -207,7 +255,25 @@ class IndexStore(object):
         self._update_index(key, index_attributes)
                         
         return defer.maybeDeferred(self.kvs.update, {key: dict({"value":value},**index_attributes)})        
-    
+
+    def batch_put(self, batch_request):
+        """
+        Istore batch_put for indexed stuff
+
+        @param batch_request is a batch request object containing one or more keys to put
+        """
+
+        assert isinstance(batch_request, SimpleBatchRequest), 'IndexStore batch_put method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
+
+        batch={}
+        for key, (value, index_atts) in batch_request._br.iteritems():
+            self._update_index(key, index_atts)
+
+            batch[key] = dict({"value":value},**index_atts)
+
+        return defer.maybeDeferred(self.kvs.update, batch)
+
+
     def remove(self, key):
         """
         @see IStore.remove

--- a/ion/core/data/store.py
+++ b/ion/core/data/store.py
@@ -170,7 +170,7 @@ class SimpleBatchRequest(object):
 
         self._br = {}
 
-    def add_request(self,key, value, index_attributes=None):
+    def add_request(self,key, value=None, index_attributes=None):
         """
         @param key The key to the Cassandra row
         @param value The value of the value column in the Cassandra row
@@ -265,11 +265,16 @@ class IndexStore(object):
 
         assert isinstance(batch_request, SimpleBatchRequest), 'IndexStore batch_put method takes a SimpleBatchRequest object, got type: %s' % type(batch_request)
 
+
         batch={}
         for key, (value, index_atts) in batch_request._br.iteritems():
             self._update_index(key, index_atts)
 
-            batch[key] = dict({"value":value},**index_atts)
+            if value is not None:
+                batch[key] = dict({"value":value},**index_atts)
+            else:
+                # Don't overwrite this row, update it!
+                self.kvs[key].update(index_atts)
 
         return defer.maybeDeferred(self.kvs.update, batch)
 

--- a/ion/services/coi/datastore.py
+++ b/ion/services/coi/datastore.py
@@ -20,7 +20,7 @@ from twisted.internet import defer
 import ion.util.procutils as pu
 from ion.core.process.process import ProcessFactory
 from ion.core.process.service_process import ServiceProcess, ServiceClient
-from ion.core.exception import ReceivedError, ApplicationError
+from ion.core.exception import ReceivedError, ApplicationError, IonError
 
 from ion.services.coi.resource_registry import resource_client
 from ion.core.messaging.message_client import MessageClient
@@ -210,7 +210,7 @@ class DataStoreWorkbench(WorkBench):
         while len(keys_to_get) > 0:
             new_links_to_get.clear()
 
-            def_list = []
+            batch_req = self._blob_store.new_batch_request()
             #@TODO - put some error checking here so that we don't overflow due to a stupid request!
             for key in keys_to_get:
                 # Short cut if we have already got it!
@@ -227,30 +227,12 @@ class DataStoreWorkbench(WorkBench):
                     # only add new items to get if they meet our criteria, meaning they are not in the excluded type list
                     new_links_to_get.update(obj.ChildLinks)
                 else:
-                    def_list.append((self._blob_store.get(key), key))
+                    batch_req.add_request( key)
 
+            result_dict = yield self._blob_store.batch_get(batch_req)
 
-            result_list = yield defer.DeferredList([x[0] for x in def_list])
-            dl_fails = filter(lambda x: not x[1][0], enumerate(result_list))
-            if len(dl_fails) > 0:
-                msg = "Errors (%s) getting link from blob store\n\n" % len(dl_fails)
-                for idx, d_res in dl_fails:
-                    msg += "Key: %s, Failure: %s\n" % (sha1_to_hex(def_list[idx][1]), str(d_res[1]))
-
-                raise DataStoreWorkBenchError(msg)
-
-            # now, let's check for Nones to get a summary of errors
-            dl_nones = filter(lambda x: x[1][1] is None, enumerate(result_list))
-            if len(dl_nones) > 0:
-                msg = "Blobs not found in blob store (%d)" % len(dl_nones)
-                for idx, d_res in dl_nones:
-                    msg += "Key: %s" % sha1_to_hex(def_list[idx][1])
-
-                raise DataStoreWorkBenchError(msg)
-
-            for result, blob in result_list:
+            for key, blob in result_dict.iteritems():
                 # these should never happen becuase we check for them above, but leaving them in for now...
-                assert result==True, 'Error getting link from blob store!'
                 assert blob is not None, 'Blob not found in blob store!'
 
                 wse = gpb_wrapper.StructureElement.parse_structure_element(blob)
@@ -562,8 +544,9 @@ class DataStoreWorkbench(WorkBench):
             local_keys = workbench_keys.intersection(need_keys)
 
 
-            def_commit_list = []
-            def_blob_list = []
+            batch_commit_req = self._commit_store.new_batch_request()
+            batch_blob_req = self._blob_store.new_batch_request()
+
             key_list = []
             for key in local_keys:
                 try:
@@ -575,29 +558,28 @@ class DataStoreWorkbench(WorkBench):
 
                 # @TODO Assumption is that this check is less costly than getting it from the remote service
                 key_list.append(key)
-                def_commit_list.append((self._commit_store.has_key(key), key))
-                def_blob_list.append((self._blob_store.has_key(key), key))
+                batch_commit_req.add_request(key)
+                batch_blob_req.add_request(key)
+
 
             if key_list:
-                result_commit_list = yield defer.DeferredList([x[0] for x in def_commit_list])
-                result_blob_list = yield defer.DeferredList([x[0] for x in def_blob_list])
+                def_list = []
+                def_list.append(self._commit_store.batch_has_key(batch_commit_req))
+                def_list.append(self._blob_store.batch_has_key(batch_blob_req))
 
-                # find issues with either list
-                cl_fails = filter(lambda x: not x[1][0], enumerate(result_commit_list))
-                bl_fails = filter(lambda x: not x[1][0], enumerate(result_blob_list))
+                dl_res = yield defer.DeferredList(def_list)
 
-                if len(cl_fails) > 0 or len(bl_fails) > 0:
-                    msg = "Push had errors (%d) on blob/commit store has_key:\n\n" % len(cl_fails) + len(bl_fails)
-                    for idx, cfail in cl_fails:
-                        msg += "C Key: %s, Failure %s\n" % (sha1_to_hex(def_commit_list[idx][1]), str(cfail[1]))
-                    for idx, bfail in bl_fails:
-                        msg += "B Key: %s, Failure %s\n" % (sha1_to_hex(def_blob_list[idx][1]), str(cfail[1]))
+                assert dl_res[0][0] is True, 'batch_has_key failed for commits'
+                assert dl_res[1][0] is True, 'batch_has_key failed for blobs'
 
-                    # no local modifications at this point - don't need to clear
-                    raise DataStoreWorkBenchError(msg)
+                result_commit_dict = dl_res[0][1]
+                result_blob_dict = dl_res[1][1]
 
                 # Remove
-                for key, res1, have_blob, res2, have_commit in zip(key_list, result_blob_list, result_commit_list):
+                for key in key_list:
+
+                    have_blob = result_blob_dict[key]
+                    have_commit = result_commit_dict[key]
 
                     if have_blob or have_commit:
                         need_keys.remove(key)
@@ -637,25 +619,23 @@ class DataStoreWorkbench(WorkBench):
             self._update_repo_to_head(repo,new_head, truncate_commits=False)
 
         # Put any new blobs
-        def_list = []
+        batch_request = self._blob_store.new_batch_request()
         for key in new_blob_keys:
 
             element = self._workbench_cache.get(key)
 
-            def_list.append(self._blob_store.put(key, element.serialize()))
+            batch_request.add_request(key, value=element.serialize())
 
-        # we need to check problems in the put here
-        dl_res = yield defer.DeferredList(def_list)
-        dl_fails = filter(lambda x: not x[1][0], enumerate(dl_res))
-        if len(dl_fails) > 0:
-            msg = "Errors (%s) putting blob to blob store\n\n" % len(dl_fails)
-            for idx, d_res in dl_fails:
-                msg += "%s\nFailure: %s\n\n" % (str(self._workbench_cache.get(new_blob_keys[idx])), str(d_res[1]))
+        try:
+            yield self._blob_store.batch_put(batch_request)
+
+        except ex:
+            log.exception('Something went horrible wrong a batch_put operation!')
 
             for repostate in pushmsg.repositories:
                 self.clear_repository_key(repostate.repository_key)
 
-            raise DataStoreWorkBenchError(msg)
+            raise DataStoreWorkBenchError('Unable to complete batch_put to blob store')
 
         """
         ### Now everything goes in one batch...
@@ -738,13 +718,6 @@ class DataStoreWorkbench(WorkBench):
 
 
                 if key not in head_keys:
-                    """
-                    defd = self._commit_store.put(key = key,
-                                       value = wse.serialize(),
-                                       index_attributes = attributes)
-                    def_list.append((defd, key, wse))
-                    """
-
                     batch.add_request(key, wse.serialize(), attributes)
 
                 else:
@@ -760,9 +733,6 @@ class DataStoreWorkbench(WorkBench):
                                 attributes[BRANCH_NAME] = ','.join([attributes[BRANCH_NAME],branch.branchkey])
 
 
-                    """
-                    new_head_list.append({'key':key, 'value':wse.serialize(), 'index_attributes':attributes})
-                    """
                     batch.add_request(key, wse.serialize(), attributes)
 
 
@@ -779,70 +749,6 @@ class DataStoreWorkbench(WorkBench):
 
         yield self._commit_store.batch_put(batch)
         # Nothing to check in the result, let any exceptions bubble up.
-
-        """
-            for key, columns in rows.items():
-                if key not in head_keys:
-                    clear_head_list.append(key)
-
-                    # Any commit which is currently a head will have the correct branch names set.
-                    # Just delete the branch names for the ones that are no longer heads.
-
-        dl_res = yield defer.DeferredList([x[0] for x in def_list])
-        dl_fails = filter(lambda x: not x[1][0], enumerate(dl_res))
-        if len(dl_fails) > 0:
-            msg = "Errors (%s) putting commit to store\n\n" % len(dl_fails)
-            for idx, d_res in dl_fails:
-                _, ckey, cwse = def_list[idx]
-                msg += "Key: %s\nElement: %s\nFailure: %s" % (sha1_to_hex(ckey), str(cwse), str(d_res[1]))
-
-            for repostate in pushmsg.repositories:
-                self.clear_repository_key(repostate.repository_key)
-
-            raise DataStoreWorkBenchError(msg)
-
-        def_list = []
-        for new_head in new_head_list:
-
-            def_list.append(self._commit_store.put(**new_head))
-
-        dl_res = yield defer.DeferredList(def_list)
-        dl_fails = filter(lambda x: not x[1][0], enumerate(dl_res))
-        if len(dl_fails) > 0:
-            msg = "Errors (%s) putting new_head_list commit to store\n\n" % len(dl_fails)
-            for idx, d_res in dl_fails:
-                nhlkey = new_head_list[idx]['key']
-                nhlval = new_head_list[idx]['value']
-                msg += "Key: %s\nElement: %s\nFailure: %s" % (sha1_to_hex(nhlkey), str(nhlval), str(d_res[1]))
-
-            for repostate in pushmsg.repositories:
-                self.clear_repository_key(repostate.repository_key)
-
-            raise DataStoreWorkBenchError(msg)
-
-        def_list = []
-        for key in clear_head_list:
-
-            def_list.append((self._commit_store.update_index(key=key, index_attributes={BRANCH_NAME:''}), key))
-
-        dl_res = yield defer.DeferredList([x[0] for x in def_list])
-        dl_fails = filter(lambda x: not x[1][0], enumerate(dl_res))
-        if len(dl_fails) > 0:
-            msg = "Errors (%s) updating index to commit store\n\n" % len(dl_fails)
-            for idx, d_res in dl_fails:
-                key = def_list[idx][1]
-                msg += "Key: %s, Failure: %s" % (sha1_to_hex(key), str(d_res[1]))
-
-            for repostate in pushmsg.repositories:
-                self.clear_repository_key(repostate.repository_key)
-
-            raise DataStoreWorkBenchError(msg)
-
-        #import pprint
-        #print 'After update to heads'
-        #pprint.pprint(self._commit_store.kvs)
-
-        """
 
 
 
@@ -899,16 +805,12 @@ class DataStoreWorkbench(WorkBench):
             raise DataStoreWorkBenchError('Invalid put blobs request. Bad Message Type!', request.ResponseCodes.BAD_REQUEST)
 
         def_list = []
-        for blob in request.blob_elements:
-            def_list.append((self._blob_store.put(blob.key, blob.SerializeToString()), blob.key))
+        batch_request = self._blob_store.new_batch_request()
 
-        dl_res = yield defer.DeferredList([x[0] for x in def_list])
-        dl_fails = filter(lambda x: not x[1][0], enumerate(dl_res))     # extract, with indexes, which items in the deferred list have False as first member of result tuple
-        if len(dl_fails) > 0:
-            msg = "Failures (%d) putting to blob store:\n\n" % len(dl_fails)
-            for idx, res in dl_fails:
-                msg += "Key: %s, Failure: %s\n" % (sha1_to_hex(def_list[idx][1]), str(res[1]))
-            raise DataStoreWorkBenchError(msg)
+        for blob in request.blob_elements:
+            batch_request.add_request(blob.key, blob.SerializeToString())
+
+        yield self._blob_store.batch_put(batch_request)
 
         yield self._process.reply_ok(message)
         log.info("op_put_blobs: Complete!")
@@ -928,7 +830,7 @@ class DataStoreWorkbench(WorkBench):
 
         response = yield self._process.message_client.create_instance(BLOBS_MESSAGE_TYPE)
 
-        def_list = []
+        batch_request = self._blob_store.new_batch_request()
         for key in request.blob_keys:
             element = self._workbench_cache.get(key)
 
@@ -939,18 +841,11 @@ class DataStoreWorkbench(WorkBench):
                 link.SetLink(obj)
 
                 continue
+            batch_request.add_request(key)
 
-            def_list.append((self._blob_store.get(key), key))
+        res_dict = yield self._blob_store.batch_get(batch_request)
 
-        res_list = yield defer.DeferredList([x[0] for x in def_list])
-        dl_fails = filter(lambda x: not x[1][0], enumerate(res_list))     # extract, with indexes, which items in the deferred list have False as first member of result tuple
-        if len(dl_fails) > 0:
-            msg = "Failures (%d) fetching blobs from store:\n\n" % len(dl_fails)
-            for idx, res in dl_fails:
-                msg += "Key: %s, Failure: %s\n" % (sha1_to_hex(def_list[idx][1]), str(res[1]))
-            raise DataStoreWorkBenchError(msg)
-
-        for result, blob in res_list:
+        for key, blob in res_dict:
             if blob is None:
                 raise DataStoreWorkBenchError('Invalid fetch objects request. Key Not Found!', request.ResponseCodes.NOT_FOUND)
 
@@ -1007,6 +902,11 @@ class DataStoreWorkbench(WorkBench):
     def flush_repo_to_backend(self, repo):
         """
         Flush any repositories in the backend to the the workbench backend storage
+
+        @TODO - this has never been a problem and is not really subject to timeouts. Therefore we are not changing it to
+        use batch requests at this time.
+
+
         """
 
         # This is simpler than a push - all of these are guaranteed to be new objects!

--- a/ion/services/coi/datastore.py
+++ b/ion/services/coi/datastore.py
@@ -845,7 +845,7 @@ class DataStoreWorkbench(WorkBench):
 
         res_dict = yield self._blob_store.batch_get(batch_request)
 
-        for key, blob in res_dict:
+        for key, blob in res_dict.iteritems():
             if blob is None:
                 raise DataStoreWorkBenchError('Invalid fetch objects request. Key Not Found!', request.ResponseCodes.NOT_FOUND)
 


### PR DESCRIPTION
Added batch operations to istore interface and implemented these methods for the in memory and cassandra store. Modified the data store to use the batch operations to give the datastore a proper atomic database change operation due to the failure of the parallel writes in operation.
