### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,7 +8,7 @@ ioncore-python - Python Capability Container and Core Modules
 ===========================================================
 
 This project provides a Python process execution framework (capability
-container, CC) with core, auxilliary and testing functions for deploying,
+container, CC) with core, auxiliary and testing functions for deploying,
 running and testing capability container processes within a standard local and
 distributed execution environment.
 


### PR DESCRIPTION
ooici, I've corrected a typographical error in the documentation of the [ioncore-python](https://github.com/ooici/ioncore-python) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
